### PR TITLE
アカウント登録画面を表示

### DIFF
--- a/src/app/account/account.factory.coffee
+++ b/src/app/account/account.factory.coffee
@@ -7,13 +7,27 @@ AccountFactory = ($location, $q, $http, localStorageService, toastr, $translate)
       defer = $q.defer()
       $http.post(host + 'session', params)
         .success((data) ->
-          defer.resolve data
           localStorageService.set 'access_token', data.access_token
           toastr.success $translate.instant('MESSAGES.LOGIN')
           $location.path '/'
+          defer.resolve data
           return
         ).error (data) ->
           defer.reject data
+          return
+      return defer.promise
+
+    postEmailUserRegistration: (params) ->
+      defer = $q.defer()
+      $http.post(host + 'email_user/registrations', params)
+        .success((data) ->
+          toastr.success $translate.instant('MESSAGES.SEND_MAIL')
+          $location.path '/'
+          defer.resolve data
+          return
+        ).error (data) ->
+          if (typeof data != 'undefined')
+            defer.reject data
           return
       return defer.promise
   }

--- a/src/app/account/sign_up.controller.coffee
+++ b/src/app/account/sign_up.controller.coffee
@@ -1,0 +1,21 @@
+SignUpController = (AccountFactory) ->
+  'ngInject'
+  vm = this
+
+  vm.clearErrors = () ->
+    vm.errors = ''
+
+  vm.submit = () ->
+    params = {
+      email: vm.email
+      password: vm.password
+      password_confirmation: vm.password_confirmation
+    }
+    AccountFactory.postEmailUserRegistration(params).catch (res) ->
+      vm.errors = res.error_messages
+      return
+
+  return
+
+angular.module 'newAccountBook'
+  .controller 'SignUpController', SignUpController

--- a/src/app/account/sign_up.haml
+++ b/src/app/account/sign_up.haml
@@ -1,0 +1,65 @@
+.col-md-9
+  .panel.panel-default
+    .panel-heading
+      %span.glyphicon.glyphicon-leaf
+      %span{translate: 'TITLES.SIGN_UP'}
+    .panel-body#with-background
+      .alert.alert-danger{role: 'alert', 'ng-show': 'sign_up.errors'}
+        %button.close{'data-dismiss': 'alert', type: 'button', 'ng-click': 'sign_up.clearErrors()'}×
+        %ul{'ng-repeat': 'error in sign_up.errors'}
+          %li {{error}}
+      %form{novalidate: true, name: 'signUpForm', 'ng-submit': 'sign_up.submit()'}
+        .form-group
+          %label{for: 'email'}
+            %span{translate: 'LABELS.EMAIL'}
+            %span *
+          %input.form-control#email{type: 'email', autofocus: true, name: 'email', 'ng-model': 'sign_up.email', required: true, 'ng-maxlength': '100'}
+          %span.errors{'ng-messages': 'signUpForm.email.$error', 'ng-show': 'signUpForm.$submitted'}
+            %div{'ng-message': 'required'}
+              %span.glyphicon.glyphicon-alert
+              %span{translate: 'ERRORS.REQUIRED.EMAIL'}
+            %div{'ng-message': 'email'}
+              %span.glyphicon.glyphicon-alert
+              %span{translate: 'ERRORS.EMAIL'}
+            %div{'ng-message': 'maxlength'}
+              %span.glyphicon.glyphicon-alert
+              %span{translate: 'ERRORS.MAXLENGTH.EMAIL'}
+        .form-group
+          %label{for: 'password'}
+            %span{translate: 'LABELS.PASSWORD'}
+            %span *
+          %input.form-control#password{type: 'password', name: 'password', 'ng-model': 'sign_up.password', required: true, 'ng-maxlength': '72', 'ng-minlength': '4'}
+          %span.errors{'ng-messages': 'signUpForm.password.$error', 'ng-show': 'signUpForm.$submitted'}
+            %div{'ng-message': 'required'}
+              %span.glyphicon.glyphicon-alert
+              %span{translate: 'ERRORS.REQUIRED.PASSWORD'}
+            %div{'ng-message': 'maxlength'}
+              %span.glyphicon.glyphicon-alert
+              %span{translate: 'ERRORS.MAXLENGTH.PASSWORD'}
+            %div{'ng-message': 'minlength'}
+              %span.glyphicon.glyphicon-alert
+              %span{translate: 'ERRORS.MINLENGTH.PASSWORD'}
+        .form-group
+          %label{for: 'password_confirmation'}
+            %span{translate: 'LABELS.PASSWORD_CONFIRMATION'}
+            %span *
+          %input.form-control#password_confirmation{type: 'password', name: 'password_confirmation', 'ng-model': 'sign_up.password_confirmation', required: true, 'ng-maxlength': '72', 'ng-minlength': '4'}
+          %span.errors{'ng-messages': 'signUpForm.password_confirmation.$error', 'ng-show': 'signUpForm.$submitted'}
+            %div{'ng-message': 'required'}
+              %span.glyphicon.glyphicon-alert
+              %span{translate: 'ERRORS.REQUIRED.PASSWORD'}
+            %div{'ng-message': 'maxlength'}
+              %span.glyphicon.glyphicon-alert
+              %span{translate: 'ERRORS.MAXLENGTH.PASSWORD'}
+            %div{'ng-message': 'minlength'}
+              %span.glyphicon.glyphicon-alert
+              %span{translate: 'ERRORS.MINLENGTH.PASSWORD'}
+        %button.btn.btn-primary{type: 'submit', 'ng-disabled': 'signUpForm.$submitted && signUpForm.$invalid'}
+          %span{translate: 'BUTTONS.SIGN_UP'}
+      %hr
+      %p
+        %a{'ui-sref': 'reset_password'}
+          %span{translate: 'LINKS.FORGOT_PASSWORD'}
+      %p
+        %a{'ui-sref': 'resend_email'}
+          %span{translate: 'LINKS.RESEND_EMAIL'}

--- a/src/app/index.route.coffee
+++ b/src/app/index.route.coffee
@@ -12,5 +12,10 @@ angular.module 'newAccountBook'
         templateUrl: 'app/account/login.html'
         controllerAs: 'login'
         controller: 'LoginController'
+      .state 'sign_up',
+        url: '/sign_up'
+        templateUrl: 'app/account/sign_up.html'
+        controllerAs: 'sign_up'
+        controller: 'SignUpController'
 
     $urlRouterProvider.otherwise '/'


### PR DESCRIPTION
- アカウント登録画面を`/sign_up`接続で表示
- アカウント登録の処理を「登録する」ボタンに追加
- エラー時にはエラーを表示
- エラー時に表示されるエラーメッセージの「×」クリック時エラーメッセージを削除
