### PR TITLE
カテゴリの収支をカテゴリ一覧に表示

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -6,7 +6,7 @@ class CategoriesController < ApplicationController
   end
 
   def create
-    @category = current_user.categories.new(name: params[:name])
+    @category = current_user.categories.new(new_category_params)
     if @category.save
       head 201
     else
@@ -39,5 +39,11 @@ class CategoriesController < ApplicationController
     else
       render_error @list
     end
+  end
+
+  private
+
+  def new_category_params
+    params.permit(:name, :barance_of_payments)
   end
 end

--- a/app/views/categories/index.json.jbuilder
+++ b/app/views/categories/index.json.jbuilder
@@ -2,6 +2,7 @@ json.categories do
   json.array! @categories do |category|
     json.id category.id
     json.name category.name
+    json.barance_of_payments category.barance_of_payments
     json.breakdowns_count category.breakdowns.count
   end
 end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,6 +1,7 @@
 FactoryGirl.define do
   factory :category do
     user
+    barance_of_payments { true | false }
     sequence(:name) { |i| "カテゴリ名#{i}" }
     sequence(:position) { |i| i - 1 }
   end

--- a/spec/requests/categories_spec.rb
+++ b/spec/requests/categories_spec.rb
@@ -22,11 +22,13 @@ describe 'GET /categories', autodoc: true do
           {
             id: category.id,
             name: category.name,
+            barance_of_payments: category.barance_of_payments,
             breakdowns_count: category.breakdowns.count
           },
           {
             id: category2.id,
             name: category2.name,
+            barance_of_payments: category2.barance_of_payments,
             breakdowns_count: category2.breakdowns.count
           }
         ]
@@ -46,13 +48,16 @@ describe 'POST /categories', autodoc: true do
 
   context 'メールアドレスのユーザーがログインしている場合' do
     let!(:user) { create(:email_user, :registered) }
-    let!(:params) { { name: '名前' } }
+    let!(:params) { { name: '名前', barance_of_payments: true } }
 
     it '201を返し、カテゴリが登録できること' do
       post '/categories', params, login_headers(user)
       expect(response.status).to eq 201
 
       expect(user.categories.count).to eq 1
+      category = Category.last
+      expect(category.name).to eq '名前'
+      expect(category.barance_of_payments).to be_truthy
     end
   end
 end

--- a/src/app/components/navbar/navbar.jade
+++ b/src/app/components/navbar/navbar.jade
@@ -8,33 +8,41 @@ nav.navbar.navbar-default(role='navigation')
     ul.nav.navbar-nav
       li
         a(ui-sref='home')
-          span.glyphicon.glyphicon-home(translate='TITLES.HOME')
+          span.glyphicon.glyphicon-home#left-icon
+          span(translate='TITLES.HOME')
       li
         a
-          span.glyphicon.glyphicon-stats(translate='TITLES.DASHBOARD')
+          span.glyphicon.glyphicon-stats#left-icon
+          span(translate='TITLES.DASHBOARD')
       li
         a(ng-click='navbar.feedback()', href='')
-          span.glyphicon.glyphicon-comment(translate='TITLES.FEEDBACK')
+          span.glyphicon.glyphicon-comment#left-icon
+          span(translate='TITLES.FEEDBACK')
     ul.nav.navbar-nav.navbar-right
       li(ng-show='navbar.login_status && navbar.current_user.admin')
         a(ui-sref='admin_users')
-          span.glyphicon.glyphicon-king(translate='TITLES.ADMIN')
+          span.glyphicon.glyphicon-king#left-icon
+          span(translate='TITLES.ADMIN')
       li.dropdown.open(ng-init='isCollapsed = true' ng-click='isCollapsed = !isCollapsed' role='presentation' ng-show='navbar.login_status')
         a.dropdown-toggle(data-toggle='dropdown' aria-haspopup='true' aria-expanded='false' role: 'button' href='')
-          span.glyphicon.glyphicon-cog(translate='TITLES.SETTINGS')
+          span.glyphicon.glyphicon-cog#left-icon
+          span#left-icon(translate='TITLES.SETTINGS')
           span.caret
         ul.dropdown-menu(ng-hide='isCollapsed')
           li
             a(ui-sref='categories' translate='TITLES.CATEGORY')
       li(ng-hide='navbar.login_status')
         a(ui-sref='login')
-          span.glyphicon.glyphicon-leaf(translate='TITLES.LOGIN')
+          span.glyphicon.glyphicon-leaf#left-icon
+          span(translate='TITLES.LOGIN')
       li(ng-show='navbar.login_status')
         a(ui-sref='profile')
-          span.glyphicon.glyphicon-user {{ navbar.current_user.email }}
+          span.glyphicon.glyphicon-user#left-icon
+          span {{ navbar.current_user.email }}
       li(ng-show='navbar.login_status')
         a(ui-sref='home' ng-click='navbar.logout()')
-          span.glyphicon.glyphicon-leaf(translate='TITLES.LOGOUT')
+          span.glyphicon.glyphicon-leaf#left-icon
+          span(translate='TITLES.LOGOUT')
 
 script#feedback(type='text/ng-template')
   form(novalidate=true name='feedbackForm' ng-submit='feedback.submit()')
@@ -49,11 +57,14 @@ script#feedback(type='text/ng-template')
         input.form-control#email(type='email' name='email' ng-model='feedback.email' required=true ng-maxlength='100')
         span.errors(ng-messages='feedbackForm.email.$error' ng-show='feedbackForm.$submitted')
           div(ng-message='required')
-            span.glyphicon.glyphicon-alert(translate='ERRORS.REQUIRED.EMAIL')
+            span.glyphicon.glyphicon-alert#left-icon
+            span(translate='ERRORS.REQUIRED.EMAIL')
           div(ng-message='email')
-            span.glyphicon.glyphicon-alert(translate='ERRORS.EMAIL')
+            span.glyphicon.glyphicon-alert#left-icon
+            span(translate='ERRORS.EMAIL')
           div(ng-message='maxlength')
-            span.glyphicon.glyphicon-alert(translate='ERRORS.MAXLENGTH.EMAIL')
+            span.glyphicon.glyphicon-alert#left-icon
+            span(translate='ERRORS.MAXLENGTH.EMAIL')
 
       .form-group
         label(for='content')
@@ -62,6 +73,8 @@ script#feedback(type='text/ng-template')
         textarea.form-control(rows='5' name='content' ng-model='feedback.content' required=true ng-maxlength='1000' placeholder='{{feedback.placeholder}}')
         span.errors(ng-messages='feedbackForm.content.$error' ng-show='feedbackForm.$submitted')
           div(ng-message='required')
-            span.glyphicon.glyphicon-alert(translate='ERRORS.REQUIRED.CONTENT')
+            span.glyphicon.glyphicon-alert#left-icon
+            span(translate='ERRORS.REQUIRED.CONTENT')
           div(ng-message='maxlength')
-            span.glyphicon.glyphicon-alert(translate='ERRORS.MAXLENGTH.CONTENT')
+            span.glyphicon.glyphicon-alert#left-icon
+            span(translate='ERRORS.MAXLENGTH.CONTENT')

--- a/src/app/index.scss
+++ b/src/app/index.scss
@@ -180,11 +180,11 @@ body {
 }
 
 #right-icon {
-  padding-left: 10px;
+  padding-left: 5px;
 }
 
 #left-icon {
-  padding-right: 10px;
+  padding-right: 5px;
 }
 
 // injector

--- a/src/app/index.scss
+++ b/src/app/index.scss
@@ -105,6 +105,9 @@ body {
   span.red {
     color: #ac5e9f;
   }
+  span.green {
+    color: #5E7535;
+  }
   span.errors {
     font-family: 'Lucida Grande', Meiryo, sans-serif;
     color: #ac5e9f;

--- a/src/app/settings/categories.controller.coffee
+++ b/src/app/settings/categories.controller.coffee
@@ -2,6 +2,7 @@ CategoriesController = (SettingsFactory, $modal) ->
   'ngInject'
   vm = this
   vm.add_field = false
+  vm.new_payments = false
 
   SettingsFactory.getCategories().then (res) ->
     vm.categories = res.categories
@@ -14,7 +15,10 @@ CategoriesController = (SettingsFactory, $modal) ->
 
   vm.createCategory = (e) ->
     if e.which == 13
-      SettingsFactory.postCategory({name: vm.new_category_name}).then () ->
+      params =
+        name: vm.new_category_name
+        barance_of_payments: vm.new_payments
+      SettingsFactory.postCategory(params).then () ->
         SettingsFactory.getCategories().then (res) ->
           vm.categories = res.categories
         vm.new_category_name = ''

--- a/src/app/settings/categories.jade
+++ b/src/app/settings/categories.jade
@@ -7,9 +7,13 @@
       .col-sm-3(ng-repeat='category in categories.categories' id='{{category.id}}')
         .panel.panel-body.col-sm-11(ng-show='!category.edit_field' ng-style="{'cursor': cursor_type}" ng-mouseenter="cursor_type = 'move'")
           a.pull-right
-            span.glyphicon.glyphicon-trash#right-icon(ng-click='categories.destroyCategory($index)' ng-hide='category.breakdowns_count == 0')
+            span.glyphicon.glyphicon-trash#right-icon(ng-click='categories.destroyCategory($index)' ng-show='category.breakdowns_count == 0')
           div.category-name(ng-style="{'cursor': 'pointer'}" ng-click='categories.editCategory($index)')
             span {{ category.name }}
+          hr
+          a
+            span.glyphicon.glyphicon-th-list#left-icon
+            span {{ category.breakdowns_count }}
         .panel.panel-body.col-sm-11#category(ng-if="category.edit_field" ng-keydown='categories.updateCategory($event, $index)')
           input.category-form(ng-value='category.name' ng-model='category.edit_name' auto-focus=true type='text')
           .btn.btn-default(translate='BUTTONS.CANCEL' ng-click='category.edit_field = false')

--- a/src/app/settings/categories.jade
+++ b/src/app/settings/categories.jade
@@ -9,6 +9,8 @@
           a.pull-right
             span.glyphicon.glyphicon-trash#right-icon(ng-click='categories.destroyCategory($index)' ng-show='category.breakdowns_count == 0')
           div.category-name(ng-style="{'cursor': 'pointer'}" ng-click='categories.editCategory($index)')
+            span.glyphicon.glyphicon-plus-sign.green#left-icon(ng-show='category.barance_of_payments')
+            span.glyphicon.glyphicon-minus-sign.red#left-icon(ng-hide='category.barance_of_payments')
             span {{ category.name }}
           hr
           a
@@ -21,6 +23,14 @@
         .panel.panel-body.col-sm-11.category-plus#category(ng-click='categories.addNewPanel()' ng-class="{'panel-background': 'adding'}" ng-mouseenter="adding = true" ng-mouseleave="adding = false" ng-show="!categories.add_field")
           span.glyphicon.glyphicon-plus
         .panel.panel-body.col-sm-11#category(ng-if='categories.add_field' ng-keydown='categories.createCategory($event)')
+          .input-group
+            .input-group-btn
+              button.btn.btn-default(ng-class="{'btn-primary': !categories.new_payments}" type='button' ng-click='categories.new_payments = false')
+                span.glyphicon.glyphicon-minus-sign#left-icon
+                span(translate='BUTTONS.OUTGO')
+              button.btn.btn-default(ng-class="{'btn-info': categories.new_payments}" type='button' ng-click='categories.new_payments = true')
+                span.glyphicon.glyphicon-plus-sign#left-icon
+                span(translate='BUTTONS.INCOME')
           input.category-form(ng-model='categories.new_category_name' auto-focus=true type='text')
           .btn.btn-default(translate='BUTTONS.CANCEL' ng-click='categories.add_field = false')
 

--- a/src/assets/i18n/locale-en.json
+++ b/src/assets/i18n/locale-en.json
@@ -25,6 +25,8 @@
     "SEND": "Send Email",
     "EDIT": "Edit",
     "YES": "Yes",
+    "OUTGO": "Outgo",
+    "INCOME": "Income",
     "UPDATE": "Update",
     "CANCEL": "Cancel",
     "CLOSE": "Close"

--- a/src/assets/i18n/locale-ja.json
+++ b/src/assets/i18n/locale-ja.json
@@ -26,6 +26,8 @@
     "SEND": "送信する",
     "EDIT": "変更",
     "YES": "はい",
+    "OUTGO": "支出",
+    "INCOME": "収入",
     "UPDATE": "変更する",
     "CANCEL": "キャンセル",
     "CLOSE": "閉じる"


### PR DESCRIPTION
- カテゴリの収支をカテゴリ一覧に表示するようにしました
- カテゴリに登録されている内訳の数をカテゴリ一覧に表示するようにしました
- カテゴリの追加で、収支を選択して登録できるようにしました
- glyphiconのアイコンの左右にpaddingを追加するようにしました
