### PR TITLE
カテゴリの並び替えができるように修正する

### DIFF
--- a/src/app/settings/categories.controller.coffee
+++ b/src/app/settings/categories.controller.coffee
@@ -32,14 +32,14 @@ CategoriesController = (SettingsFactory, $modal) ->
         category.edit_field = false
 
   vm.sortable =
-    update: (e, ui) ->
+    stop: (e, ui) ->
       if (!ui.item.sortable.model)
         ui.item.sortable.cancel()
       else
         vm.category_range = []
         for key in vm.categories
           vm.category_range.push(key.id)
-          SettingsFactory.postCategoryRange({sequence: vm.category_range})
+        SettingsFactory.postCategoryRange({sequence: vm.category_range})
       return
     axis: ''
 


### PR DESCRIPTION
カテゴリの並び順が、並び替え前の状態を保存するようになっていました。
カテゴリの並び順が正しく並び替えられるように修正しました
