### PR TITLE
ユーザーのお知らせ一覧の本文をマークダウンで表示できるようにする

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,8 @@
     "angular-local-storage": "~0.2.3",
     "angular-ui-sortable": "~0.13.4",
     "angular-auto-focus": "~1.0.4",
-    "angular-flexslider": "~1.3.2"
+    "angular-flexslider": "~1.3.2",
+    "angular-marked": "~1.0.1"
   },
   "devDependencies": {
     "angular-mocks": "~1.4.2"

--- a/src/app/admin/notices.controller.coffee
+++ b/src/app/admin/notices.controller.coffee
@@ -43,6 +43,17 @@ NoticesController = (AdminFactory, $modal, $translate, toastr) ->
 
     return
 
+  vm.showNotice = (index) ->
+    notice = vm.notices[index]
+    modalInstance = $modal.open(
+      templateUrl: 'notice'
+      controller: 'AdminNewNoticeController'
+      controllerAs: 'notice'
+      resolve: { notice: notice }
+    )
+    modalInstance.result.then () ->
+      return
+
   return
 
 AdminNoticeController = ($modalInstance, AdminFactory) ->
@@ -64,6 +75,13 @@ AdminNoticeController = ($modalInstance, AdminFactory) ->
 
   return
 
+AdminNewNoticeController = (notice) ->
+  'ngInject'
+  vm = this
+  vm.notice = notice
+  return
+
 angular.module 'newAccountBook'
   .controller('AdminNoticeController', AdminNoticeController)
+  .controller('AdminNewNoticeController', AdminNewNoticeController)
   .controller('NoticesController', NoticesController)

--- a/src/app/admin/notices.jade
+++ b/src/app/admin/notices.jade
@@ -19,7 +19,8 @@ admin-menu-directive
       tr(ng-repeat='notice in admin_notices.notices')
         td
         td
-        td {{ notice.title }}
+        td
+          a(ng-click='admin_notices.showNotice($index)') {{ notice.title }}
         td {{ notice.content }}
         td {{ notice.post_at }}
 
@@ -50,3 +51,9 @@ script#new-notice(type='text/ng-template')
         label(for='content')
           span(translate='COLUMNS.CONTENT')
         textarea.form-control(rows='5' name='content' ng-model='new_notice.content' ng-maxlength='1000')
+
+script#notice(type='text/ng-template')
+  .modal-header
+    | {{ notice.notice.title }}
+  .modal-body
+    div(marked='notice.notice.content')

--- a/src/app/index.config.coffee
+++ b/src/app/index.config.coffee
@@ -1,5 +1,5 @@
 angular.module 'newAccountBook'
-  .config ($logProvider, toastrConfig, $translateProvider) ->
+  .config ($logProvider, toastrConfig, $translateProvider, markedProvider) ->
     'ngInject'
     # Enable log
     $logProvider.debugEnabled true
@@ -19,3 +19,5 @@ angular.module 'newAccountBook'
     $translateProvider.useMissingTranslationHandlerLog()
     $translateProvider.useLocalStorage()
     $translateProvider.useSanitizeValueStrategy('escaped')
+
+    markedProvider.setOptions { gfm: true }

--- a/src/app/index.module.coffee
+++ b/src/app/index.module.coffee
@@ -13,5 +13,6 @@ angular.module(
                      'pascalprecht.translate',
                      'LocalStorageModule',
                      'angular-flexslider',
+                     'hc.marked',
                      'toastr']
 )

--- a/src/app/user/mypage.jade
+++ b/src/app/user/mypage.jade
@@ -20,5 +20,7 @@
       .panel-body
 
 script#notice(type='text/ng-template')
+  .modal-header
+    | {{ notice.notice.title }}
   .modal-body
-    | {{ notice.notice.content }}
+    div(marked='notice.notice.content')


### PR DESCRIPTION
- ユーザーのお知らせ一覧のリンククリック時に、お知らせのタイトルと内容をモーダルで表示するようにしました
- モーダルで表示された内容は、マークダウンで表示できるようにしました
- 管理画面のお知らせ一覧からもモーダルでマークダウンのお知らせ内容が表示できるようにしました
