### PR TITLE
データ送信中はボタンを非活性にする

### DIFF
--- a/src/app/account/login.controller.coffee
+++ b/src/app/account/login.controller.coffee
@@ -9,6 +9,7 @@ LoginController = (AccountFactory, IndexFactory, IndexService, $location, toastr
     vm.errors = ''
 
   vm.submit = () ->
+    vm.sending = true
     params = {
       email: vm.email
       password: vm.password
@@ -17,9 +18,11 @@ LoginController = (AccountFactory, IndexFactory, IndexService, $location, toastr
       IndexFactory.getCurrentUser().then (res) ->
         IndexService.current_user = res
         $location.path '/mypage'
+        vm.sending = false
         return
     ).catch (res) ->
       vm.errors = res.error_messages
+      vm.sending = false
       return
 
   return

--- a/src/app/account/login.jade
+++ b/src/app/account/login.jade
@@ -42,7 +42,7 @@
             div(ng-message='minlength')
               span.glyphicon.glyphicon-alert#left-icon
               span(translate='ERRORS.MINLENGTH.PASSWORD')
-        button.btn.btn-success(type='submit' ng-disabled='loginForm.$submitted && loginForm.$invalid')
+        button.btn.btn-success(type='submit' ng-disabled='(loginForm.$submitted && loginForm.$invalid) || login.sending')
           span(translate='BUTTONS.LOGIN')
       hr
       p

--- a/src/app/account/resend_email.controller.coffee
+++ b/src/app/account/resend_email.controller.coffee
@@ -6,15 +6,18 @@ ResendEmailController = (AccountFactory, $translate) ->
     vm.errors = ''
 
   vm.submit = () ->
+    vm.sending = true
     params = {
       email: vm.email
     }
-    AccountFactory.patchResendEmail(params).catch (res) ->
-      console.log res.error_messages
+    AccountFactory.patchResendEmail(params).then((res) ->
+      vm.sending = false
+    ).catch (res) ->
       if res.error_messages[0] == 'Not Found'
         vm.errors = [$translate.instant('MESSAGES.NOT_FOUND_EMAIL')]
       else
         vm.errors = res.error_messages
+      vm.sending = false
 
   return
 

--- a/src/app/account/resend_email.jade
+++ b/src/app/account/resend_email.jade
@@ -27,7 +27,7 @@
             div(ng-message='maxlength')
               span.glyphicon.glyphicon-alert#left-icon
               span(translate='ERRORS.MAXLENGTH.EMAIL')
-        button.btn.btn-success(type='submit' ng-disabled='resendEmailForm.$submitted && resendEmailForm.$invalid')
+        button.btn.btn-success(type='submit' ng-disabled='(resendEmailForm.$submitted && resendEmailForm.$invalid) || resend_email.sending')
           span(translate='BUTTONS.SEND')
       hr
       p

--- a/src/app/account/reset_password.controller.coffee
+++ b/src/app/account/reset_password.controller.coffee
@@ -6,11 +6,15 @@ ResetPasswordController = (AccountFactory, $translate) ->
     vm.errors = ''
 
   vm.submit = () ->
+    vm.sending = true
     params = {
       email: vm.email
     }
-    AccountFactory.postResetPassword(params).catch (res) ->
+    AccountFactory.postResetPassword(params).then((res) ->
+      vm.sending = false
+    ).catch (res) ->
       vm.errors = res.error_messages
+      vm.sending = false
 
   return
 

--- a/src/app/account/reset_password.jade
+++ b/src/app/account/reset_password.jade
@@ -28,7 +28,7 @@
               span.glyphicon.glyphicon-alert#left-icon
               span(translate='ERRORS.MAXLENGTH.EMAIL')
  
-        button.btn.btn-success(type='submit' ng-disabled='resetPasswordForm.$submitted && resetPasswordForm.$invalid')
+        button.btn.btn-success(type='submit' ng-disabled='(resetPasswordForm.$submitted && resetPasswordForm.$invalid) || reset_password.sending')
           span(translate='BUTTONS.SEND')
       hr
       p

--- a/src/app/account/sign_up.controller.coffee
+++ b/src/app/account/sign_up.controller.coffee
@@ -6,13 +6,17 @@ SignUpController = (AccountFactory) ->
     vm.errors = ''
 
   vm.submit = () ->
+    vm.sending = true
     params = {
       email: vm.email
       password: vm.password
       password_confirmation: vm.password_confirmation
     }
-    AccountFactory.postEmailUserRegistration(params).catch (res) ->
+    AccountFactory.postEmailUserRegistration(params).then((res) ->
+      vm.sending = false
+    ).catch (res) ->
       vm.errors = res.error_messages
+      vm.sending = false
       return
 
   return

--- a/src/app/account/sign_up.jade
+++ b/src/app/account/sign_up.jade
@@ -57,7 +57,7 @@
             div(ng-message='minlength')
               span.glyphicon.glyphicon-alert
               span(translate='ERRORS.MINLENGTH.PASSWORD')
-        button.btn.btn-success(type='submit' ng-disabled='signUpForm.$submitted && signUpForm.$invalid')
+        button.btn.btn-success(type='submit' ng-disabled='(signUpForm.$submitted && signUpForm.$invalid) || sign_up.sending')
           span(translate='BUTTONS.SIGN_UP')
       hr
       p

--- a/src/app/components/navbar/navbar.directive.coffee
+++ b/src/app/components/navbar/navbar.directive.coffee
@@ -43,6 +43,7 @@ FeedbackController = (IndexFactory, $translate, $modalInstance, toastr) ->
     return
 
   vm.submit = () ->
+    vm.sending = true
     params = {}
     if vm.current_user != undefined
       params =
@@ -55,9 +56,11 @@ FeedbackController = (IndexFactory, $translate, $modalInstance, toastr) ->
 
     IndexFactory.postFeedback(params).then( ->
       $modalInstance.close()
+      vm.sending = false
       return
     ).catch (res) ->
       vm.errors = res.error_messages
+      vm.sending = false
       return
 
   vm.cancel = () ->

--- a/src/app/components/navbar/navbar.jade
+++ b/src/app/components/navbar/navbar.jade
@@ -49,7 +49,7 @@ nav.navbar.navbar-default(role='navigation')
 script#feedback(type='text/ng-template')
   form(novalidate=true name='feedbackForm' ng-submit='feedback.submit()')
     .modal-header
-      button.btn.btn-success(type='submit' ng-disabled='feedbackForm.$submitted && feedbackForm.$invalid' translate='BUTTONS.SEND')
+      button.btn.btn-success(type='submit' ng-disabled='(feedbackForm.$submitted && feedbackForm.$invalid) || feedback.sending' translate='BUTTONS.SEND')
       a.btn.btn-default(ng-click='feedback.cancel()' translate='BUTTONS.CLOSE')
     .modal-body
       .form-group(ng-if='feedback.current_user == undefined')


### PR DESCRIPTION
以下の画面のボタンをデータ送信中、非活性にするようにしました
- ログイン画面
- アカウント登録画面
- パスワードリセット画面
- メール再送信画面
- フィードバック送信モーダル
