### PR TITLE
管理画面にメッセージ送信モーダルを追加

### DIFF
--- a/app/views/admin/user/feedbacks/index.json.jbuilder
+++ b/app/views/admin/user/feedbacks/index.json.jbuilder
@@ -1,6 +1,7 @@
 json.feedbacks do
   json.array! @feedbacks do |feedback|
     json.id feedback.id
-    json.content simple_format(feedback.content)
+    json.content feedback.content
+    json.checked feedback.checked
   end
 end

--- a/spec/requests/admin/user/feedbacks_spec.rb
+++ b/spec/requests/admin/user/feedbacks_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 describe 'GET /admin/users/:user_id/feedbacks', autodoc: true do
-  include ActionView::Helpers::TextHelper
-
   let!(:admin_user) { create(:email_user, :admin_user, :registered) }
   let!(:user) { create(:email_user, :registered) }
   let!(:feedback) { create(:feedback, user: user) }
@@ -24,7 +22,8 @@ describe 'GET /admin/users/:user_id/feedbacks', autodoc: true do
         feedbacks: [
           {
             id: feedback.id,
-            content: simple_format(feedback.content)
+            content: feedback.content,
+            checked: feedback.checked
           }
         ]
       }

--- a/src/app/admin/admin.factory.coffee
+++ b/src/app/admin/admin.factory.coffee
@@ -57,6 +57,22 @@ AdminFactory = ($location, $q, localStorageService, $http, $translate, IndexServ
             return
       return defer.promise
 
+    getUserFeedbacks: (user_id) ->
+      defer = $q.defer()
+      token = localStorageService.get('access_token')
+      if typeof(token) != "undefined" && token != null
+        login_headers = {
+          headers: { Authorization: 'Token token=' + token }
+        }
+        $http.get host + 'admin/users/' + user_id + '/feedbacks', login_headers
+          .success((data) ->
+            defer.resolve data
+            return
+          ).error (data) ->
+            defer.reject data
+            return
+      return defer.promise
+
     patchFeedbackCheck: (feedback_id) ->
       defer = $q.defer()
       token = localStorageService.get('access_token')

--- a/src/app/admin/users.controller.coffee
+++ b/src/app/admin/users.controller.coffee
@@ -1,4 +1,4 @@
-UsersController = (AdminFactory) ->
+UsersController = (AdminFactory, $modal) ->
   'ngInject'
   vm = this
 
@@ -23,7 +23,36 @@ UsersController = (AdminFactory) ->
     vm.offset_numbers = total_array.filter (x) ->
       return x % 20 == 0
 
+  vm.message = (user_id) ->
+    modalInstance = $modal.open(
+      templateUrl: 'new-message'
+      controller: 'NewMessageController'
+      controllerAs: 'message'
+      resolve: { user_id: user_id }
+      backdrop: 'static'
+    )
+    modalInstance.result.then () ->
+      return
+
+  return
+
+NewMessageController = (IndexService, AdminFactory, $modalInstance, user_id) ->
+  'ngInject'
+  vm = this
+
+  vm.cancel = () ->
+    $modalInstance.dismiss()
+
+  IndexService.modal_loading = true
+  AdminFactory.getUserFeedbacks(user_id).then((res) ->
+    vm.feedbacks = res.feedbacks
+    IndexService.modal_loading = false
+  ).catch (res) ->
+    IndexService.modal_loading = false
+
+    return
   return
 
 angular.module 'newAccountBook'
+  .controller 'NewMessageController', NewMessageController
   .controller 'UsersController', UsersController

--- a/src/app/admin/users.jade
+++ b/src/app/admin/users.jade
@@ -15,6 +15,7 @@ admin-menu-directive
         th ID
         th
         th
+        th
         th(translate='COLUMNS.NICKNAME')
         th(translate='COLUMNS.EMAIL')
         th(translate='COLUMNS.LAST_LOGIN_TIME')
@@ -27,6 +28,38 @@ admin-menu-directive
         td
           span.label(ng-class='user.type_label_name') {{ user.type }}
         td
+          a(href='' ng-click='admin_users.message(user.id)')
+            span.glyphicon.glyphicon-envelope
+        td
           span {{ user.nickname }}
         td {{ user.email }}
         td {{ user.last_sign_in_at }}
+
+script#new-message(type='text/ng-template')
+  form(novalidate=true name='messageForm' ng-submit='message.submit()')
+    .modal-header
+      button.btn.btn-success(type='submit' ng-disabled='messageForm.$submitted && messageForm.$invalid' translate='BUTTONS.SEND')
+      a.btn.btn-default(ng-click='message.cancel()' translate='BUTTONS.CLOSE')
+    .modal-body
+      loading-directive(target='modal')
+      pre(ng-show='message.feedbacks[message.feedback_index_id]')
+        | {{ message.feedbacks[message.feedback_index_id].content }}
+      .form-group.form-inline(ng-hide='message.feedbacks.length == 0')
+        label(for='feedback.id' translate='LABELS.FEEDBACK')
+        select.form-control(ng-model='message.feedback_index_id')
+          option(ng-value='')
+          option(ng-value='$index' name='feedback.id' ng-repeat='feedback in message.feedbacks')
+            | {{ feedback.content | truncate:true:10 }}
+        label.label.label-info(ng-show='message.feedbacks[message.feedback_index_id].checked' translate='LABELS.FINISHED')
+      .form-group
+        label(for='content')
+          span(translate='LABELS.MESSAGE')
+          span *
+        textarea.form-control(rows='10' name='content' ng-model='admin_message.content' ng-maxlength='10000' required=true)
+        span.errors(ng-messages='messageForm.content.$error' ng-show='messageForm.$submitted && messageForm.content.$dirty')
+          div(ng-message='required')
+            span.glyphicon.glyphicon-alert#left-icon
+            span(translate='ERRORS.REQUIRED.MESSAGE')
+          div(ng-message='maxlength')
+            span.glyphicon.glyphicon-alert#left-icon
+            span(translate='ERRORS.MAXLENGTH.MESSAGE')

--- a/src/assets/i18n/locale-en.json
+++ b/src/assets/i18n/locale-en.json
@@ -11,6 +11,7 @@
     "LOGIN": "Log in",
     "LOGOUT": "Logout",
     "MESSAGE_LIST": "Message List",
+    "MESSAGE": "Message",
     "MYPAGE": "Mypage",
     "MYPAGE_TOP": "Mypage TOP",
     "NOTICE_LIST": "Notice List",
@@ -46,7 +47,9 @@
   },
   "LABELS": {
     "BREAKDOWNS": "Breakdowns",
+    "FEEDBACK": "Feedback",
     "FEEDBACK_EMAIL": "your Email address",
+    "FINISHED": "Finished",
     "EMAIL": "Email address",
     "INCOME": "Income",
     "OUTGO": "Outgo",

--- a/src/assets/i18n/locale-ja.json
+++ b/src/assets/i18n/locale-ja.json
@@ -12,6 +12,7 @@
     "LOGIN": "ログイン",
     "LOGOUT": "ログアウト",
     "MESSAGE_LIST": "メッセージ一覧",
+    "MESSAGE": "メッセージ",
     "MYPAGE": "マイページ",
     "MYPAGE_TOP": "マイページトップ",
     "NOTICE_LIST": "お知らせ一覧",
@@ -47,7 +48,9 @@
   },
   "LABELS": {
     "BREAKDOWNS": "内訳",
+    "FEEDBACK": "フィードバック",
     "FEEDBACK_EMAIL": "連絡先メールアドレス",
+    "FINISHED": "対応済",
     "EMAIL": "メールアドレス",
     "INCOME": "収入",
     "OUTGO": "支出",


### PR DESCRIPTION
メッセージ送信のモーダルを管理画面のユーザー一覧に追加しました。

そのモーダルでは、対応済みのフィードバックが対応済みかわかるように、フィードバック選択時に「対応済み」ラベルを表示するようにしました。
