### PR TITLE
メッセージに未読、既読機能を追加

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -7,5 +7,6 @@ class MessagesController < ApplicationController
 
   def show
     @message = current_user.messages.find(params[:id])
+    @message.to_read unless @message.read?
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -6,4 +6,8 @@ class Message < ActiveRecord::Base
             presence: true,
             length: { maximum: Settings.message.content.maximum_length }
   validates :user, presence: true
+
+  def to_read
+    update(read: true)
+  end
 end

--- a/app/views/admin/messages/index.json.jbuilder
+++ b/app/views/admin/messages/index.json.jbuilder
@@ -1,9 +1,11 @@
 json.messages do
   json.array! @messages do |message|
     json.id message.id
+    json.read message.read
     json.user_name message.user._name
     json.feedback_content message.feedback.try(:content)
     json.content message.content
+    json.created_at I18n.l(message.created_at)
   end
 end
 

--- a/app/views/messages/index.json.jbuilder
+++ b/app/views/messages/index.json.jbuilder
@@ -2,6 +2,7 @@ json.messages do
   json.array! @messages do |message|
     json.id message.id
     json.content message.content
+    json.read message.read
     json.created_at I18n.l(message.created_at)
   end
 end

--- a/db/migrate/20160314020907_add_read_to_messages.rb
+++ b/db/migrate/20160314020907_add_read_to_messages.rb
@@ -1,0 +1,5 @@
+class AddReadToMessages < ActiveRecord::Migration
+  def change
+    add_column :messages, :read, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160301023631) do
+ActiveRecord::Schema.define(version: 20160314020907) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,6 +55,8 @@ ActiveRecord::Schema.define(version: 20160301023631) do
     t.datetime "deleted_at"
     t.integer  "user_id"
     t.integer  "position"
+    t.integer  "places_count"
+    t.integer  "breakdowns_count"
   end
 
   add_index "categories", ["user_id"], name: "index_categories_on_user_id", using: :btree
@@ -86,6 +88,7 @@ ActiveRecord::Schema.define(version: 20160301023631) do
     t.datetime "updated_at"
     t.datetime "deleted_at"
     t.string   "type"
+    t.boolean  "read",        default: false
   end
 
   create_table "monthly_counts", force: :cascade do |t|

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -5,5 +5,6 @@ FactoryGirl.define do
       feedback
     end
     sequence(:content) { |n| "メッセージ内容#{n}" }
+    read false
   end
 end

--- a/spec/requests/admin/messages_spec.rb
+++ b/spec/requests/admin/messages_spec.rb
@@ -33,15 +33,19 @@ describe 'GET /admin/messages?offset=offset', autodoc: true do
           messages: [
             {
               id: message2.id,
+              read: false,
               user_name: message2.user._name,
               feedback_content: message2.feedback.try(:content),
-              content: message2.content
+              content: message2.content,
+              created_at: I18n.l(message2.created_at)
             },
             {
               id: message1.id,
+              read: false,
               user_name: message1.user._name,
               feedback_content: message1.feedback.try(:content),
-              content: message1.content
+              content: message1.content,
+              created_at: I18n.l(message1.created_at)
             }
           ],
           total_count: 2
@@ -59,9 +63,11 @@ describe 'GET /admin/messages?offset=offset', autodoc: true do
           messages: [
             {
               id: message1.id,
+              read: false,
               user_name: message1.user._name,
               feedback_content: message1.feedback.try(:content),
-              content: message1.content
+              content: message1.content,
+              created_at: I18n.l(message1.created_at)
             }
           ],
           total_count: 2

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -16,6 +16,8 @@ describe 'GET /messages/:id', autodoc: true do
     let!(:message) { create(:message, user: user) }
 
     it '200とメッセージを返すこと' do
+      expect(message.read).to be_falsey
+
       get "/messages/#{message.id}", '', login_headers(user)
       expect(response.status).to eq 200
 
@@ -25,6 +27,8 @@ describe 'GET /messages/:id', autodoc: true do
         created_at: I18n.l(message.created_at)
       }
       expect(response.body).to be_json_as(json)
+      message.reload
+      expect(message.read).to be_truthy
     end
   end
 

--- a/spec/requests/mypage_spec.rb
+++ b/spec/requests/mypage_spec.rb
@@ -105,7 +105,7 @@ describe 'GET /messages', autodoc: true do
   context 'ユーザーにメッセージがある場合' do
     let!(:user) { create(:email_user, :registered) }
     let!(:user2) { create(:email_user, :registered) }
-    let!(:message1) { create(:message, user: user) }
+    let!(:message1) { create(:message, user: user, read: true) }
     let!(:message2) { create(:message, user: user2) }
     let!(:message3) { create(:message, user: user) }
 
@@ -118,11 +118,13 @@ describe 'GET /messages', autodoc: true do
           {
             id: message3.id,
             content: message3.content,
+            read: false,
             created_at: I18n.l(message3.created_at)
           },
           {
             id: message1.id,
             content: message1.content,
+            read: true,
             created_at: I18n.l(message1.created_at)
           }
         ]

--- a/src/app/admin/messages.jade
+++ b/src/app/admin/messages.jade
@@ -13,12 +13,17 @@ admin-menu-directive
       tr
         th(translate='COLUMNS.USER')
         th(translate='LABELS.FEEDBACK')
+        th
         th(translate='COLUMNS.CONTENT')
+        th(translate='COLUMNS.CREATED_AT')
         th
       tr(ng-repeat='message in admin_messages.messages')
         td {{ message.user_name }}
         td {{ message.feedback_content | truncate:true:10 }}
         td
+          label.label.label-warning(translate='LABELS.UNREAD' ng-show='!message.read')
+        td
           a(href='' ng-click='admin_messages.showMessage($index)') {{ message.content | truncate:true:20 }}
+        td {{ message.created_at }}
         td
           a(href='' ng-click='admin_messages.destroyMessage($index)' translate='LINKS.DELETE')

--- a/src/app/user/mypage.jade
+++ b/src/app/user/mypage.jade
@@ -27,4 +27,4 @@
             span#post_at メッセージはありません
           li(ng-repeat='message in mypage.messages | limitTo:5')
             span#post_at {{ message.created_at | date:'yyyy-MM-dd' }}
-            a(ui-sref='message({id: message.id})') {{ message.content | truncate:true:20 }}
+            a(ui-sref='message({id: message.id})' ng-style="{'font-weight': message.read ? 'normal' : 'bold'}") {{ message.content | truncate:true:20 }}

--- a/src/assets/i18n/locale-en.json
+++ b/src/assets/i18n/locale-en.json
@@ -63,7 +63,8 @@
     "NICKNAME": "Nickname",
     "NO_SETTINGS": "(No Settings)",
     "EMAIL_LOGIN": "Login via Email",
-    "SELECTED": "Selected"
+    "SELECTED": "Selected",
+    "UNREAD": "Unread"
   },
   "TOOLTIPS": {
     "SET_CATEGORY": "Add a Category to the Shop",

--- a/src/assets/i18n/locale-ja.json
+++ b/src/assets/i18n/locale-ja.json
@@ -64,7 +64,8 @@
     "NICKNAME": "ニックネーム",
     "NO_SETTINGS": "（未設定）",
     "EMAIL_LOGIN": "メールアドレスでログイン",
-    "SELECTED": "登録済"
+    "SELECTED": "登録済",
+    "UNREAD": "未読"
   },
   "TOOLTIPS": {
     "SET_CATEGORY": "カテゴリを設定",


### PR DESCRIPTION
- マイページのメッセージ詳細の確認時に、既読になるようにしました
- メッセージが既読になると、マイページのメッセージ一覧の文字は`font-weight`がboldからnormalに変更されるようにしました
- 管理画面で、未読の場合は「未読」ラベルが表示されるようにしました
