### PR TITLE
401認証エラー時のエラーハンドリングを追加

### DIFF
--- a/src/app/admin/admin.factory.coffee
+++ b/src/app/admin/admin.factory.coffee
@@ -6,222 +6,209 @@ AdminFactory = ($location, $q, localStorageService, $http, $translate, IndexServ
     getUser: (user_id) ->
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.get host + 'admin/users/' + user_id, login_headers
-          .success((data) ->
-            defer.resolve data
-            return
-          ).error (data) ->
-            defer.reject data
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.get host + 'admin/users/' + user_id, login_headers
+        .success((data) ->
+          defer.resolve data
+          return
+        ).error (data) ->
+          defer.reject data
+          return
       return defer.promise
 
     getUsers: (offset) ->
       IndexService.loading = true
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.get host + 'admin/users?offset=' + offset, login_headers
-          .success((data) ->
-            defer.resolve data
-            IndexService.loading = false
-            return
-          ).error (data) ->
-            defer.reject data
-            IndexService.loading = false
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.get host + 'admin/users?offset=' + offset, login_headers
+        .success((data) ->
+          defer.resolve data
+          IndexService.loading = false
+          return
+        ).error (data) ->
+          defer.reject data
+          IndexService.loading = false
+          return
       return defer.promise
 
     getFeedbacks: (offset) ->
       IndexService.loading = true
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.get host + 'admin/feedbacks?offset=' + offset, login_headers
-          .success((data) ->
-            defer.resolve data
-            IndexService.loading = false
-            return
-          ).error (data) ->
-            defer.reject data
-            IndexService.loading = false
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.get host + 'admin/feedbacks?offset=' + offset, login_headers
+        .success((data) ->
+          defer.resolve data
+          IndexService.loading = false
+          return
+        ).error (data) ->
+          defer.reject data
+          IndexService.loading = false
+          return
       return defer.promise
 
     getUserFeedbacks: (user_id) ->
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.get host + 'admin/users/' + user_id + '/feedbacks', login_headers
-          .success((data) ->
-            defer.resolve data
-            return
-          ).error (data) ->
-            defer.reject data
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.get host + 'admin/users/' + user_id + '/feedbacks', login_headers
+        .success((data) ->
+          defer.resolve data
+          return
+        ).error (data) ->
+          defer.reject data
+          return
       return defer.promise
 
     patchFeedbackCheck: (feedback_id) ->
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.patch host + 'admin/feedbacks/' + feedback_id + '/check', '', login_headers
-          .success((data) ->
-            defer.resolve data
-            return
-          ).error (data) ->
-            defer.reject data
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.patch host + 'admin/feedbacks/' + feedback_id + '/check', '', login_headers
+        .success((data) ->
+          defer.resolve data
+          return
+        ).error (data) ->
+          defer.reject data
+          return
       return defer.promise
 
     getNotices: (offset) ->
       IndexService.loading = true
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.get host + 'admin/notices?offset=' + offset, login_headers
-          .success((data) ->
-            defer.resolve data
-            IndexService.loading = false
-            return
-          ).error (data) ->
-            defer.reject data
-            IndexService.loading = false
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.get host + 'admin/notices?offset=' + offset, login_headers
+        .success((data) ->
+          defer.resolve data
+          IndexService.loading = false
+          return
+        ).error (data) ->
+          defer.reject data
+          IndexService.loading = false
+          return
       return defer.promise
 
     postNotice: (params) ->
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.post host + 'admin/notices', params, login_headers
-          .success((data) ->
-            defer.resolve data
-            return
-          ).error (data) ->
-            defer.reject data
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.post host + 'admin/notices', params, login_headers
+        .success((data) ->
+          defer.resolve data
+          return
+        ).error (data) ->
+          defer.reject data
+          return
       return defer.promise
 
     getMessages: (offset) ->
       IndexService.loading = true
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.get host + 'admin/messages?offset=' + offset, login_headers
-          .success((data) ->
-            defer.resolve data
-            IndexService.loading = false
-            return
-          ).error (data) ->
-            defer.reject data
-            IndexService.loading = false
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.get host + 'admin/messages?offset=' + offset, login_headers
+        .success((data) ->
+          defer.resolve data
+          IndexService.loading = false
+          return
+        ).error (data) ->
+          defer.reject data
+          IndexService.loading = false
+          return
       return defer.promise
 
     postMessage: (user_id, params) ->
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.post host + 'admin/users/' + user_id + '/messages', params, login_headers
-          .success((data) ->
-            defer.resolve data
-            toastr.success $translate.instant('MESSAGES.SEND_MESSAGE')
-            return
-          ).error (data) ->
-            defer.reject data
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.post host + 'admin/users/' + user_id + '/messages', params, login_headers
+        .success((data) ->
+          defer.resolve data
+          toastr.success $translate.instant('MESSAGES.SEND_MESSAGE')
+          return
+        ).error (data) ->
+          defer.reject data
+          return
       return defer.promise
 
     patchMessage: (message_id, params) ->
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.patch host + 'admin/messages/' + message_id, params, login_headers
-          .success((data) ->
-            defer.resolve data
-            return
-          ).error (data) ->
-            defer.reject data
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.patch host + 'admin/messages/' + message_id, params, login_headers
+        .success((data) ->
+          defer.resolve data
+          return
+        ).error (data) ->
+          defer.reject data
+          return
       return defer.promise
 
     deleteMessage: (message_id) ->
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.delete host + 'admin/messages/' + message_id, login_headers
-          .success((data) ->
-            defer.resolve data
-            return
-          ).error (data) ->
-            defer.reject data
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.delete host + 'admin/messages/' + message_id, login_headers
+        .success((data) ->
+          defer.resolve data
+          return
+        ).error (data) ->
+          defer.reject data
+          return
       return defer.promise
 
     patchNotice: (notice_id, params) ->
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.patch host + 'admin/notices/' + notice_id, params, login_headers
-          .success((data) ->
-            defer.resolve data
-            return
-          ).error (data) ->
-            defer.reject data
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.patch host + 'admin/notices/' + notice_id, params, login_headers
+        .success((data) ->
+          defer.resolve data
+          return
+        ).error (data) ->
+          defer.reject data
+          return
       return defer.promise
 
     deleteNotice: (notice_id) ->
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.delete host + 'admin/notices/' + notice_id, login_headers
-          .success((data) ->
-            defer.resolve data
-            return
-          ).error (data) ->
-            defer.reject data
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.delete host + 'admin/notices/' + notice_id, login_headers
+        .success((data) ->
+          defer.resolve data
+          return
+        ).error (data) ->
+          defer.reject data
+          return
       return defer.promise
   }
 

--- a/src/app/index.config.coffee
+++ b/src/app/index.config.coffee
@@ -1,5 +1,5 @@
 angular.module 'newAccountBook'
-  .config ($logProvider, toastrConfig, $translateProvider, markedProvider) ->
+  .config ($logProvider, toastrConfig, $translateProvider, markedProvider, $httpProvider) ->
     'ngInject'
     # Enable log
     $logProvider.debugEnabled true
@@ -21,3 +21,5 @@ angular.module 'newAccountBook'
     $translateProvider.useSanitizeValueStrategy('escaped')
 
     markedProvider.setOptions { gfm: true }
+
+    $httpProvider.interceptors.push('AuthInterceptor')

--- a/src/app/index.factory.coffee
+++ b/src/app/index.factory.coffee
@@ -6,17 +6,16 @@ IndexFactory = ($location, $q, localStorageService, $http, toastr, $translate, I
     getCurrentUser: () ->
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.get host + 'user', login_headers
-          .success((data) ->
-            defer.resolve data
-            return
-          ).error (data) ->
-            defer.reject data
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.get host + 'user', login_headers
+        .success((data) ->
+          defer.resolve data
+          return
+        ).error (data) ->
+          defer.reject data
+          return
       return defer.promise
 
     postFeedback: (params) ->

--- a/src/app/index.factory.coffee
+++ b/src/app/index.factory.coffee
@@ -6,16 +6,17 @@ IndexFactory = ($location, $q, localStorageService, $http, toastr, $translate, I
     getCurrentUser: () ->
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      login_headers = {
-        headers: { Authorization: 'Token token=' + token }
-      }
-      $http.get host + 'user', login_headers
-        .success((data) ->
-          defer.resolve data
-          return
-        ).error (data) ->
-          defer.reject data
-          return
+      if token != null
+        login_headers = {
+          headers: { Authorization: 'Token token=' + token }
+        }
+        $http.get host + 'user', login_headers
+          .success((data) ->
+            defer.resolve data
+            return
+          ).error (data) ->
+            defer.reject data
+            return
       return defer.promise
 
     postFeedback: (params) ->

--- a/src/app/index.service.coffee
+++ b/src/app/index.service.coffee
@@ -8,5 +8,18 @@ IndexService = () ->
   vm.notice_loading = false
   vm.message_loading = false
 
+  return
+
+AuthInterceptor = ($q, $location) ->
+  vm = this
+
+  vm.responseError = (res) ->
+    if res.status == 401
+      $location.path 'login'
+    $q.reject(res)
+
+  return
+
 angular.module 'newAccountBook'
   .service 'IndexService', IndexService
+  .service 'AuthInterceptor', AuthInterceptor

--- a/src/app/settings/settings.factory.coffee
+++ b/src/app/settings/settings.factory.coffee
@@ -6,282 +6,265 @@ SettingsFactory = ($location, $q, $http, localStorageService, toastr, $translate
     postCategoryRange: (params) ->
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.post host + 'categories/sort', params, login_headers
-          .success((data) ->
-            defer.resolve data
-            return
-          ).error (data) ->
-            defer.reject data
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.post host + 'categories/sort', params, login_headers
+        .success((data) ->
+          defer.resolve data
+          return
+        ).error (data) ->
+          defer.reject data
+          return
       return defer.promise
 
     getCategories: () ->
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.get host + 'categories', login_headers
-          .success((data) ->
-            defer.resolve data
-            return
-          ).error (data) ->
-            defer.reject data
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.get host + 'categories', login_headers
+        .success((data) ->
+          defer.resolve data
+          return
+        ).error (data) ->
+          defer.reject data
+          return
       return defer.promise
 
     postCategory: (params) ->
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.post host + 'categories', params, login_headers
-          .success((data) ->
-            defer.resolve data
-            return
-          ).error (data) ->
-            defer.reject data
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.post host + 'categories', params, login_headers
+        .success((data) ->
+          defer.resolve data
+          return
+        ).error (data) ->
+          defer.reject data
+          return
       return defer.promise
 
     patchCategory: (category_id, params) ->
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.patch host + 'categories/' + category_id, params, login_headers
-          .success((data) ->
-            defer.resolve data
-            return
-          ).error (data) ->
-            defer.reject data
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.patch host + 'categories/' + category_id, params, login_headers
+        .success((data) ->
+          defer.resolve data
+          return
+        ).error (data) ->
+          defer.reject data
+          return
       return defer.promise
 
     deleteCategory: (category_id) ->
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.delete host + 'categories/' + category_id, login_headers
-          .success((data) ->
-            defer.resolve data
-            return
-          ).error (data) ->
-            defer.reject data
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.delete host + 'categories/' + category_id, login_headers
+        .success((data) ->
+          defer.resolve data
+          return
+        ).error (data) ->
+          defer.reject data
+          return
       return defer.promise
 
     getBreakdowns: (category_id) ->
       IndexService.modal_loading = true
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.get host + 'categories/' + category_id + '/breakdowns', login_headers
-          .success((data) ->
-            defer.resolve data
-            IndexService.modal_loading = false
-            return
-          ).error (data) ->
-            defer.reject data
-            IndexService.modal_loading = false
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.get host + 'categories/' + category_id + '/breakdowns', login_headers
+        .success((data) ->
+          defer.resolve data
+          IndexService.modal_loading = false
+          return
+        ).error (data) ->
+          defer.reject data
+          IndexService.modal_loading = false
+          return
       return defer.promise
 
     postBreakdown: (category_id, params) ->
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.post host + 'categories/' + category_id + '/breakdowns', params, login_headers
-          .success((data) ->
-            defer.resolve data
-            return
-          ).error (data) ->
-            defer.reject data
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.post host + 'categories/' + category_id + '/breakdowns', params, login_headers
+        .success((data) ->
+          defer.resolve data
+          return
+        ).error (data) ->
+          defer.reject data
+          return
       return defer.promise
 
     patchBreakdown: (category_id, breakdown_id, params) ->
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.patch "#{host}categories/#{category_id}/breakdowns/#{breakdown_id}", params, login_headers
-          .success((data) ->
-            defer.resolve data
-            return
-          ).error (data) ->
-            defer.reject data
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.patch "#{host}categories/#{category_id}/breakdowns/#{breakdown_id}", params, login_headers
+        .success((data) ->
+          defer.resolve data
+          return
+        ).error (data) ->
+          defer.reject data
+          return
       return defer.promise
 
     deleteBreakdown: (category_id, breakdown_id) ->
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.delete "#{host}categories/#{category_id}/breakdowns/#{breakdown_id}", login_headers
-          .success((data) ->
-            defer.resolve data
-            return
-          ).error (data) ->
-            defer.reject data
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.delete "#{host}categories/#{category_id}/breakdowns/#{breakdown_id}", login_headers
+        .success((data) ->
+          defer.resolve data
+          return
+        ).error (data) ->
+          defer.reject data
+          return
       return defer.promise
 
     getPlaces: () ->
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.get host + 'places', login_headers
-          .success((data) ->
-            defer.resolve data
-            return
-          ).error (data) ->
-            defer.reject data
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.get host + 'places', login_headers
+        .success((data) ->
+          defer.resolve data
+          return
+        ).error (data) ->
+          defer.reject data
+          return
       return defer.promise
 
     getCategoryPlaces: (category_id) ->
       IndexService.modal_loading = true
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.get host + 'categories/' + category_id + '/places', login_headers
-          .success((data) ->
-            defer.resolve data
-            IndexService.modal_loading = false
-            return
-          ).error (data) ->
-            defer.reject data
-            IndexService.modal_loading = false
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.get host + 'categories/' + category_id + '/places', login_headers
+        .success((data) ->
+          defer.resolve data
+          IndexService.modal_loading = false
+          return
+        ).error (data) ->
+          defer.reject data
+          IndexService.modal_loading = false
+          return
       return defer.promise
 
     getPlaceCategories: (place_id) ->
       IndexService.modal_loading = true
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.get host + 'places/' + place_id + '/categories', login_headers
-          .success((data) ->
-            defer.resolve data
-            IndexService.modal_loading = false
-            return
-          ).error (data) ->
-            defer.reject data
-            IndexService.modal_loading = false
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.get host + 'places/' + place_id + '/categories', login_headers
+        .success((data) ->
+          defer.resolve data
+          IndexService.modal_loading = false
+          return
+        ).error (data) ->
+          defer.reject data
+          IndexService.modal_loading = false
+          return
       return defer.promise
 
     postPlace: (params) ->
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.post host + 'places', params, login_headers
-          .success((data) ->
-            defer.resolve data
-            return
-          ).error (data) ->
-            defer.reject data
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.post host + 'places', params, login_headers
+        .success((data) ->
+          defer.resolve data
+          return
+        ).error (data) ->
+          defer.reject data
+          return
       return defer.promise
 
     patchPlace: (place_id, params) ->
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.patch host + 'places/' + place_id, params, login_headers
-          .success((data) ->
-            defer.resolve data
-            return
-          ).error (data) ->
-            defer.reject data
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.patch host + 'places/' + place_id, params, login_headers
+        .success((data) ->
+          defer.resolve data
+          return
+        ).error (data) ->
+          defer.reject data
+          return
       return defer.promise
 
     patchPlaceCategory: (place_id, category_id) ->
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.patch host + 'places/' + place_id + '/categories/' + category_id, '', login_headers
-          .success((data) ->
-            defer.resolve data
-            return
-          ).error (data) ->
-            defer.reject data
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.patch host + 'places/' + place_id + '/categories/' + category_id, '', login_headers
+        .success((data) ->
+          defer.resolve data
+          return
+        ).error (data) ->
+          defer.reject data
+          return
       return defer.promise
 
     deletePlace: (place_id) ->
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.delete host + 'places/' + place_id, login_headers
-          .success((data) ->
-            defer.resolve data
-            return
-          ).error (data) ->
-            defer.reject data
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.delete host + 'places/' + place_id, login_headers
+        .success((data) ->
+          defer.resolve data
+          return
+        ).error (data) ->
+          defer.reject data
+          return
       return defer.promise
 
     deletePlaceCategory: (place_id, category_id) ->
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.delete host + 'places/' + place_id + '/categories/' + category_id, login_headers
-          .success((data) ->
-            defer.resolve data
-            return
-          ).error (data) ->
-            defer.reject data
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.delete host + 'places/' + place_id + '/categories/' + category_id, login_headers
+        .success((data) ->
+          defer.resolve data
+          return
+        ).error (data) ->
+          defer.reject data
+          return
       return defer.promise
   }
 

--- a/src/app/user/user.factory.coffee
+++ b/src/app/user/user.factory.coffee
@@ -6,87 +6,82 @@ UserFactory = ($location, $q, $http, localStorageService, toastr, $translate, In
     patchNickname: (params) ->
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.patch host + 'user', params, login_headers
-          .success((data) ->
-            defer.resolve data
-            return
-          ).error (data) ->
-            defer.reject data
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.patch host + 'user', params, login_headers
+        .success((data) ->
+          defer.resolve data
+          return
+        ).error (data) ->
+          defer.reject data
+          return
       return defer.promise
 
     getNotices: (offset) ->
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.get host + 'notices?offset=' + offset, login_headers
-          .success((data) ->
-            defer.resolve data
-            return
-          ).error (data) ->
-            defer.reject data
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.get host + 'notices?offset=' + offset, login_headers
+        .success((data) ->
+          defer.resolve data
+          return
+        ).error (data) ->
+          defer.reject data
+          return
       return defer.promise
 
     getMessages: (offset) ->
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.get host + 'messages?offset=' + offset, login_headers
-          .success((data) ->
-            defer.resolve data
-            return
-          ).error (data) ->
-            defer.reject data
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.get host + 'messages?offset=' + offset, login_headers
+        .success((data) ->
+          defer.resolve data
+          return
+        ).error (data) ->
+          defer.reject data
+          return
       return defer.promise
 
     getNotice: (notice_id) ->
       IndexService.loading = true
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.get host + 'notices/' + notice_id, login_headers
-          .success((data) ->
-            defer.resolve data
-            IndexService.loading = false
-            return
-          ).error (data) ->
-            defer.reject data
-            IndexService.loading = false
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.get host + 'notices/' + notice_id, login_headers
+        .success((data) ->
+          defer.resolve data
+          IndexService.loading = false
+          return
+        ).error (data) ->
+          defer.reject data
+          IndexService.loading = false
+          return
       return defer.promise
 
     getMessage: (message_id) ->
       IndexService.loading = true
       defer = $q.defer()
       token = localStorageService.get('access_token')
-      if typeof(token) != "undefined" && token != null
-        login_headers = {
-          headers: { Authorization: 'Token token=' + token }
-        }
-        $http.get host + 'messages/' + message_id, login_headers
-          .success((data) ->
-            defer.resolve data
-            IndexService.loading = false
-            return
-          ).error (data) ->
-            defer.reject data
-            IndexService.loading = false
-            return
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.get host + 'messages/' + message_id, login_headers
+        .success((data) ->
+          defer.resolve data
+          IndexService.loading = false
+          return
+        ).error (data) ->
+          defer.reject data
+          IndexService.loading = false
+          return
       return defer.promise
   }
 


### PR DESCRIPTION
以下の場合、401認証エラーを発生し、ログイン画面に遷移するように変更しました
- 一般ユーザーが管理画面へ接続する
- 外部ユーザーが管理画面へ接続する
- 外部ユーザーがログイン必須画面に接続する
