### PR TITLE
お知らせの詳細画面をpublicで確認できるように変更

### DIFF
--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -1,5 +1,5 @@
 class NoticesController < ApplicationController
-  before_action :authenticate
+  before_action :authenticate, only: %i(index)
 
   def index
     @notices = Notice::Fetcher.all(params: params).published

--- a/spec/requests/notices_spec.rb
+++ b/spec/requests/notices_spec.rb
@@ -4,9 +4,16 @@ describe 'GET /notices/:id', autodoc: true do
   context 'ログインしていない場合' do
     let!(:notice) { create(:notice) }
 
-    it '401が返ってくること' do
+    it '200が返ってくること' do
       get "/notices/#{notice.id}"
-      expect(response.status).to eq 401
+      expect(response.status).to eq 200
+
+      json = {
+        title: notice.title,
+        content: notice.content,
+        post_at: notice.post_at.strftime('%Y-%m-%d')
+      }
+      expect(response.body).to be_json_as(json)
     end
   end
 

--- a/src/app/user/notice.controller.coffee
+++ b/src/app/user/notice.controller.coffee
@@ -1,6 +1,11 @@
-NoticeController = ($stateParams, UserFactory) ->
+NoticeController = ($stateParams, UserFactory, IndexFactory) ->
   'ngInject'
   vm = this
+
+  IndexFactory.getCurrentUser().then((res) ->
+    vm.current_user = res
+  ).catch (res) ->
+    return
 
   UserFactory.getNotice($stateParams.id).then (res) ->
     vm.notice = res

--- a/src/app/user/notice.jade
+++ b/src/app/user/notice.jade
@@ -1,7 +1,7 @@
-.col-md-3
+.col-md-3(ng-show='notice.current_user')
   user-menu-directive
 
-.col-md-9
+div(ng-class="{'col-md-9': notice.current_user, 'col-md-12': !notice.current_user}")
   .panel.panel-default
     .panel-heading
       span.glyphicon.glyphicon-film#left-icon


### PR DESCRIPTION
お知らせ詳細画面のみ、ログインしていなくても表示できるようにしました。
