### PR TITLE
ログイン画面、アカウント登録画面のフォントが異なる

### DIFF
--- a/src/app/account/login.jade
+++ b/src/app/account/login.jade
@@ -4,7 +4,7 @@
 .col-md-9
   .panel.panel-default
     .panel-heading
-      span.glyphicon.glyphicon-leaf
+      span.glyphicon.glyphicon-leaf#left-icon
       span(translate='TITLES.LOGIN')
     .panel-body#with-background
       .alert.alert-danger(role='alert' ng-show='login.errors')
@@ -14,8 +14,8 @@
       form(novalidate=true name='loginForm' ng-submit='login.submit()')
         .form-group
           label(for='email')
-          span(translate='LABELS.EMAIL')
-          span *
+            span(translate='LABELS.EMAIL')
+            span *
           input.form-control#email(type='email' autofocus=true name='email' ng-model='login.email' required=true ng-maxlength='100')
           span.errors(ng-messages='loginForm.email.$error' ng-show='loginForm.email.$dirty || loginForm.$submitted')
             div(ng-message='required')

--- a/src/app/account/resend_email.jade
+++ b/src/app/account/resend_email.jade
@@ -4,7 +4,7 @@
 .col-md-9
   .panel.panel-default
     .panel-heading
-      span.glyphicon.glyphicon-leaf#left-icon
+      span.glyphicon.glyphicon-heart#left-icon
       span(translate='TITLES.RESEND_EMAIL')
     .panel-body#with-background
       .alert.alert-danger(role='alert' ng-show='resend_email.errors')
@@ -14,8 +14,8 @@
       form(novalidate=true name='resendEmailForm' ng-submit='resend_email.submit()')
         .form-group
           label(for='email')
-          span(translate='LABELS.EMAIL')
-          span *
+            span(translate='LABELS.EMAIL')
+            span *
           input.form-control#email(type='email' autofocus=true name='email' ng-model='resend_email.email' required=true ng-maxlength='100')
           span.errors(ng-messages='resendEmailForm.email.$error' ng-show='resendEmailForm.$submitted || resendEmailForm.email.$dirty')
             div(ng-message='required')

--- a/src/app/account/sign_up.jade
+++ b/src/app/account/sign_up.jade
@@ -4,7 +4,7 @@
 .col-md-9
   .panel.panel-default
     .panel-heading
-      span.glyphicon.glyphicon-leaf
+      span.glyphicon.glyphicon-heart#left-icon
       span(translate='TITLES.SIGN_UP')
     .panel-body#with-background
       .alert.alert-danger(role='alert' ng-show='sign_up.errors')


### PR DESCRIPTION
アカウントメニューにあるカラムのフォントをすべて統一しました。

また、パネルのタイトルのglyphiconの横にpaddingを追加するようにしました。
