### PR TITLE
収支を登録できるapiを追加

### DIFF
--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -1,0 +1,19 @@
+class RecordsController < ApplicationController
+  before_action :authenticate
+
+  def create
+    @record = current_user.records.new(record_params)
+    if @record.save
+      head 201
+    else
+      render_error @record
+    end
+  end
+
+  private
+
+  def record_params
+    params.permit(:published_at, :charge,
+                  :category_id, :breakdown_id, :place_id)
+  end
+end

--- a/app/models/breakdown.rb
+++ b/app/models/breakdown.rb
@@ -1,5 +1,6 @@
 class Breakdown < ActiveRecord::Base
   belongs_to :category
+  has_many :records
 
   validates :name, presence: true
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -3,6 +3,7 @@ class Category < ActiveRecord::Base
   has_many :breakdowns
   has_many :categorize_places, dependent: :destroy
   has_many :places, through: :categorize_places
+  has_many :records
 
   validates :name,
             presence: true,

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -2,6 +2,7 @@ class Place < ActiveRecord::Base
   belongs_to :user
   has_many :categorize_places, dependent: :destroy
   has_many :categories, through: :categorize_places
+  has_many :records
 
   validates :name,
             presence: true,

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -4,5 +4,5 @@ class Record < ActiveRecord::Base
   belongs_to :breakdown
   belongs_to :place
 
-  validates :charge, presence: true
+  validates :published_at, :charge, presence: true
 end

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -1,0 +1,8 @@
+class Record < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :category
+  belongs_to :breakdown
+  belongs_to :place
+
+  validates :charge, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ActiveRecord::Base
   has_many :categories
   has_many :places
   has_many :messages
+  has_many :records
 
   enum status: { registered: 2, inactive: 1 }
 

--- a/config/locales/activerecord_ja.yml
+++ b/config/locales/activerecord_ja.yml
@@ -24,6 +24,8 @@ ja:
         name: 内訳
       categorize_place:
         category_id: カテゴリ
+      record:
+        charge: 金額
     errors:
       models:
         user:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,8 @@ Rails.application.routes.draw do
   resources :places, only: %i(index create update destroy) do
     resources :categories, only: %i(index update destroy), module: :place
   end
+  resources :records, only: %i(create)
+
   resource :user, only: %i(show update)
   resource :feedback, only: %i(create)
 end

--- a/spec/factories/records.rb
+++ b/spec/factories/records.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :record do
+    published_at Time.zone.today
+    user
+    category
+    charge { rand(0..10_000) }
+    sequence(:memo) { |i| "めも#{i}" }
+  end
+end

--- a/spec/models/breakdown_spec.rb
+++ b/spec/models/breakdown_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Breakdown, type: :model do
   it { is_expected.to belong_to(:category) }
+  it { is_expected.to have_many(:records) }
 
   it { is_expected.to validate_presence_of(:name) }
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Category, type: :model do
   it { is_expected.to have_many(:breakdowns) }
   it { is_expected.to have_many(:categorize_places) }
   it { is_expected.to have_many(:places).through(:categorize_places) }
+  it { is_expected.to have_many(:records) }
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_length_of(:name).is_at_most(100) }
 end

--- a/spec/models/place_spec.rb
+++ b/spec/models/place_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Place, type: :model do
   it { is_expected.to belong_to(:user) }
   it { is_expected.to have_many(:categorize_places) }
   it { is_expected.to have_many(:categories).through(:categorize_places) }
+  it { is_expected.to have_many(:records) }
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_length_of(:name).is_at_most(100) }
 end

--- a/spec/models/record_spec.rb
+++ b/spec/models/record_spec.rb
@@ -6,5 +6,6 @@ RSpec.describe Record, type: :model do
   it { is_expected.to belong_to(:breakdown) }
   it { is_expected.to belong_to(:place) }
 
+  it { is_expected.to validate_presence_of(:published_at) }
   it { is_expected.to validate_presence_of(:charge) }
 end

--- a/spec/models/record_spec.rb
+++ b/spec/models/record_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe Record, type: :model do
+  it { is_expected.to belong_to(:user) }
+  it { is_expected.to belong_to(:category) }
+  it { is_expected.to belong_to(:breakdown) }
+  it { is_expected.to belong_to(:place) }
+
+  it { is_expected.to validate_presence_of(:charge) }
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,4 +5,5 @@ RSpec.describe User, type: :model do
   it { is_expected.to have_many(:categories) }
   it { is_expected.to have_many(:places) }
   it { is_expected.to have_many(:messages) }
+  it { is_expected.to have_many(:records) }
 end

--- a/spec/requests/records_spec.rb
+++ b/spec/requests/records_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+describe 'POST /records', autodoc: true do
+  let!(:user) { create(:email_user, :registered) }
+  let!(:category) { create(:category, user: user) }
+  let!(:breakdown) { create(:breakdown, category: category) }
+  let!(:place) { create(:place, user: user) }
+  let!(:charge) { '8000' }
+  let!(:params) do
+    {
+      charge: charge, published_at: Time.zone.today,
+      category_id: category.id, breakdown_id: breakdown.id, place_id: place.id
+    }
+  end
+
+  context 'ログインしていない場合' do
+    it '401が返ってくること' do
+      post '/records', ''
+
+      expect(response.status).to eq 401
+    end
+  end
+
+  context '正しい値が登録された場合' do
+    it '201が返ってくること' do
+      post '/records', params, login_headers(user)
+
+      expect(response.status).to eq 201
+
+      record = Record.last
+      expect(record.category).to eq category
+      expect(record.breakdown).to eq breakdown
+      expect(record.place).to eq place
+    end
+  end
+
+  context '金額が空の場合' do
+    let(:charge) { '' }
+
+    it '422とエラーメッセージが返ってくること' do
+      post '/records', params, login_headers(user)
+
+      expect(response.status).to eq 422
+      json = {
+        error_messages: ['金額を入力してください']
+      }
+      expect(response.body).to be_json_as(json)
+    end
+  end
+end


### PR DESCRIPTION
以下のパラメータで収支が登録できるようにします
- 日時
- 金額
- カテゴリid
- 内訳id
- お店id
