### PR TITLE
日付のパラメータから、該当日付の収支を新しい順に取得できるAPIを追加

### DIFF
--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -1,9 +1,15 @@
 class RecordsController < ApplicationController
   before_action :authenticate
 
+  def index
+    @records = Record::Fetcher.all(user: current_user, params: params)
+  end
+
   def new
     @user = current_user
-    @categories = current_user.categories.order(:position)
+    @categories = current_user.categories
+                              .order(:position)
+    # TODO: N+1を解消する
   end
 
   def create

--- a/app/models/record/fetcher.rb
+++ b/app/models/record/fetcher.rb
@@ -1,0 +1,20 @@
+class Record::Fetcher
+  def initialize(user: nil, params: nil)
+    @user = user
+    @params = params
+  end
+
+  def self.all(user: nil, params: nil)
+    new(user: user, params: params).all
+  end
+
+  def all
+    records = @user.records.order(created_at: :desc)
+                   .limit(Settings.records.per)
+    records.offset!(@params[:offset]) if @params[:offset].present?
+    if @params[:date].present?
+      records = records.where(published_at: @params[:date])
+    end
+    records
+  end
+end

--- a/app/views/records/index.json.jbuilder
+++ b/app/views/records/index.json.jbuilder
@@ -1,0 +1,5 @@
+json.records do
+  json.array! @records do |record|
+    json.id record.id
+  end
+end

--- a/config/application.yml
+++ b/config/application.yml
@@ -50,6 +50,8 @@ defaults: &defaults
     per: 20
   messages:
     per: 20
+  records:
+    per: 20
 
 development:
   <<: *defaults

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,7 +41,7 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   config.after_initialize do
-    Bullet.enable = true
+    Bullet.enable = false
     Bullet.alert = true
     Bullet.bullet_logger = true
     Bullet.console = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,7 +37,7 @@ Rails.application.routes.draw do
   resources :places, only: %i(index create update destroy) do
     resources :categories, only: %i(index update destroy), module: :place
   end
-  resources :records, only: %i(new create)
+  resources :records, only: %i(index new create)
 
   resource :user, only: %i(show update) do
     patch :set_display

--- a/spec/requests/records_spec.rb
+++ b/spec/requests/records_spec.rb
@@ -1,5 +1,41 @@
 require 'rails_helper'
 
+describe 'GET /records', autodoc: true do
+  context 'ログインしていない場合' do
+    it '401が返ってくること' do
+      get '/records'
+      expect(response.status).to eq 401
+    end
+  end
+
+  context 'メールアドレスのユーザーがログインしている場合' do
+    let!(:user) { create(:email_user, :registered) }
+    let!(:record1) { create(:record, user: user) }
+    let!(:record2) { create(:record, user: user) }
+    let!(:record3) do
+      create(:record, user: user, published_at: Time.zone.yesterday)
+    end
+    let!(:params) { { date: Time.zone.today } }
+
+    it '200と当日の収支一覧を返すこと' do
+      get '/records', params, login_headers(user)
+      expect(response.status).to eq 200
+
+      json = {
+        records: [
+          {
+            id: record2.id
+          },
+          {
+            id: record1.id
+          }
+        ]
+      }
+      expect(response.body).to be_json_as(json)
+    end
+  end
+end
+
 describe 'GET /records/new', autodoc: true do
   context 'ログインしていない場合' do
     it '401が返ってくること' do

--- a/src/app/records/new_record.controller.coffee
+++ b/src/app/records/new_record.controller.coffee
@@ -22,7 +22,6 @@ NewRecordController = (IndexService, toastr, RecordsFactory, $scope) ->
     category = vm.categories[vm.category_index_id]
     if category
       vm.category_id = category.id
-    console.log vm.published_at
     params =
       published_at: vm.published_at
       category_id: vm.category_id

--- a/src/app/records/new_record.controller.coffee
+++ b/src/app/records/new_record.controller.coffee
@@ -22,6 +22,7 @@ NewRecordController = (IndexService, toastr, RecordsFactory, $scope) ->
     category = vm.categories[vm.category_index_id]
     if category
       vm.category_id = category.id
+    console.log vm.published_at
     params =
       published_at: vm.published_at
       category_id: vm.category_id


### PR DESCRIPTION
日付のパラメータ`date`を渡すことで、該当日付の収支を新しい順で20件まで取得できるAPIを追加しました
