### PR TITLE
収支登録画面に日付の収支一覧を表示

### DIFF
--- a/app/models/record/fetcher.rb
+++ b/app/models/record/fetcher.rb
@@ -13,7 +13,7 @@ class Record::Fetcher
                    .limit(Settings.records.per)
     records.offset!(@params[:offset]) if @params[:offset].present?
     if @params[:date].present?
-      records = records.where(published_at: @params[:date])
+      records = records.where(published_at: @params[:date].to_date)
     end
     records
   end

--- a/app/views/records/index.json.jbuilder
+++ b/app/views/records/index.json.jbuilder
@@ -1,5 +1,10 @@
 json.records do
   json.array! @records do |record|
     json.id record.id
+    json.charge record.charge
+    json.category_name record.category.name
+    json.breakdown_name record.breakdown.try(:name)
+    json.place_name record.place.try(:name)
+    json.memo record.memo
   end
 end

--- a/spec/requests/records_spec.rb
+++ b/spec/requests/records_spec.rb
@@ -24,10 +24,20 @@ describe 'GET /records', autodoc: true do
       json = {
         records: [
           {
-            id: record2.id
+            id: record2.id,
+            charge: record2.charge,
+            category_name: record2.category.name,
+            breakdown_name: record2.breakdown.try(:name),
+            place_name: record2.place.try(:name),
+            memo: record2.memo
           },
           {
-            id: record1.id
+            id: record1.id,
+            charge: record1.charge,
+            category_name: record1.category.name,
+            breakdown_name: record1.breakdown.try(:name),
+            place_name: record1.place.try(:name),
+            memo: record1.memo
           }
         ]
       }

--- a/src/app/components/loading.directory.coffee
+++ b/src/app/components/loading.directory.coffee
@@ -22,6 +22,11 @@ LoadingController = (IndexService, $scope) ->
   ), ->
     vm.notice_loading = IndexService.notice_loading
 
+  $scope.$watch ( ->
+    IndexService.records_loading
+  ), ->
+    vm.records_loading = IndexService.records_loading
+
   return
 
 loadingDirective = () ->

--- a/src/app/components/loading.jade
+++ b/src/app/components/loading.jade
@@ -2,3 +2,4 @@ img(ng-src='assets/images/loader.gif' width='60px' ng-show='loading.loading' alt
 img(ng-src='assets/images/loader.gif' width='60px' ng-show='loading.modal_loading' alt='loading.target' ng-if="loading.target == 'modal'")
 img(ng-src='assets/images/loader.gif' width='60px' ng-show='loading.notice_loading' alt='loading.target' ng-if="loading.target == 'notice'")
 img(ng-src='assets/images/loader.gif' width='60px' ng-show='loading.message_loading' alt='loading.target' ng-if="loading.target == 'message'")
+img(ng-src='assets/images/loader.gif' width='60px' ng-show='loading.records_loading' alt='loading.target' ng-if="loading.target == 'records'")

--- a/src/app/index.service.coffee
+++ b/src/app/index.service.coffee
@@ -7,6 +7,7 @@ IndexService = () ->
   vm.modal_loading = false
   vm.notice_loading = false
   vm.message_loading = false
+  vm.records_loading = false
 
   return
 

--- a/src/app/records/new.jade
+++ b/src/app/records/new.jade
@@ -3,7 +3,7 @@
     span.glyphicon.glyphicon-piggy-bank#left-icon
     span(translate='TITLES.NEW_RECORD')
   .panel-body
-    .col-sm-8
+    .col-sm-6
       loading-directive
       // 表示設定のリンク
       .text-right
@@ -98,11 +98,24 @@
           .control-label.col-sm-2
             button.btn.btn-success(type='submit' ng-disabled='(newRecordForm.$submitted && newRecordForm.$invalid) || new_record.sending' translate='BUTTONS.CREATE')
     // 日付の登録一覧
-    .col-sm-4
+    .col-sm-6
       loading-directive(target='records')
       .panel.panel-default(ng-show='new_record.day_records')
         .panel-body
-          | {{ new_record.published_at | date:'yyyy年MM月dd日' }} の登録
-          ul
-            li(ng-repeat='record in new_record.day_records')
-              span {{ record.id }}
+          | {{ new_record.published_at | date:'yyyy年MM月dd日' }}
+          span(translate='LABELS.ADD_20')
+          table.table.table-condensed
+            tr(ng-repeat='record in new_record.day_records')
+              td
+                a(href='')
+                  span.glyphicon.glyphicon-arrow-left
+              td
+                label.label.label-warning {{ record.category_name }}
+              td
+                label.label.label-info {{ record.breakdown_name }}
+              td
+                label.label.label-primary {{ record.place_name }}
+              td ¥ {{ record.charge }}
+              td
+                a(href='')
+                  span.glyphicon.glyphicon-info-sign

--- a/src/app/records/new.jade
+++ b/src/app/records/new.jade
@@ -28,7 +28,7 @@
             span(translate='COLUMNS.PUBLISHED_AT')
             span.red *
           .col-sm-10
-            input.btn.btn-default(type='date' name='published_at' ng-model='new_record.published_at' datepicker-popup=true required='true')
+            input.btn.btn-default(type='date' name='published_at' ng-model='new_record.published_at' datepicker-popup=true required='true' ng-change='new_record.changeDate()')
             span.errors(ng-messages='newRecordForm.published_at.$error' ng-show='newRecordForm.$submitted && newRecordForm.published_at.$error')
               div(ng-message='required')
                 span.glyphicon.glyphicon-alert#left-icon

--- a/src/app/records/new.jade
+++ b/src/app/records/new.jade
@@ -99,6 +99,10 @@
             button.btn.btn-success(type='submit' ng-disabled='(newRecordForm.$submitted && newRecordForm.$invalid) || new_record.sending' translate='BUTTONS.CREATE')
     // 日付の登録一覧
     .col-sm-4
-      .panel.panel-default
+      loading-directive(target='records')
+      .panel.panel-default(ng-show='new_record.day_records')
         .panel-body
           | {{ new_record.published_at | date:'yyyy年MM月dd日' }} の登録
+          ul
+            li(ng-repeat='record in new_record.day_records')
+              span {{ record.id }}

--- a/src/app/records/new_record.controller.coffee
+++ b/src/app/records/new_record.controller.coffee
@@ -5,6 +5,7 @@ NewRecordController = (IndexService, toastr, RecordsFactory, $scope) ->
   vm.published_at = new Date()
   vm.settings = false
 
+  IndexService.records_loading = true
   IndexService.loading = true
   RecordsFactory.getNewRecord().then((res) ->
     vm.categories = res.categories
@@ -18,12 +19,20 @@ NewRecordController = (IndexService, toastr, RecordsFactory, $scope) ->
   ).catch (res) ->
     IndexService.loading = false
 
+  params =
+    published_at: vm.published_at
+  RecordsFactory.getRecords(params).then((res) ->
+    vm.day_records = res.records
+    IndexService.records_loading = false
+  ).catch (res) ->
+    IndexService.records_loading = false
+
   vm.submit = () ->
     category = vm.categories[vm.category_index_id]
     if category
       vm.category_id = category.id
     params =
-      published_at: vm.published_at
+      published_at: String(vm.published_at)
       category_id: vm.category_id
       breakdown_id: vm.breakdown_id
       place_id: vm.place_id

--- a/src/app/records/new_record.controller.coffee
+++ b/src/app/records/new_record.controller.coffee
@@ -39,7 +39,6 @@ NewRecordController = (IndexService, toastr, RecordsFactory, $scope) ->
       charge: vm.charge
       memo: vm.memo
     RecordsFactory.postRecord(params).then (res) ->
-      vm.published_at = new Date()
       vm.category_index_id = ''
       vm.breakdown_id = ''
       vm.place_id = ''
@@ -47,6 +46,14 @@ NewRecordController = (IndexService, toastr, RecordsFactory, $scope) ->
       vm.memo = ''
       $scope.newRecordForm.$setPristine()
       # TODO: コピーのリンクと編集のリンクを表示する
+      params =
+        published_at: vm.published_at
+      RecordsFactory.getRecords(params).then((res) ->
+        vm.day_records = res.records
+        IndexService.records_loading = false
+      ).catch (res) ->
+        IndexService.records_loading = false
+
     return
 
   vm.selectCategory = (category_index_id) ->
@@ -55,7 +62,6 @@ NewRecordController = (IndexService, toastr, RecordsFactory, $scope) ->
     return
 
   vm.checkSetting = () ->
-    console.log vm.breakdown_field
     params =
       breakdown_field: vm.breakdown_field
       place_field: vm.place_field
@@ -64,6 +70,16 @@ NewRecordController = (IndexService, toastr, RecordsFactory, $scope) ->
       vm.form_group_breakdown = vm.breakdown_field
       vm.form_group_place = vm.place_field
       vm.form_group_memo = vm.memo_field
+    return
+
+  vm.changeDate = () ->
+    params =
+      published_at: vm.published_at
+    RecordsFactory.getRecords(params).then((res) ->
+      vm.day_records = res.records
+      IndexService.records_loading = false
+    ).catch (res) ->
+      IndexService.records_loading = false
     return
 
   return

--- a/src/app/records/records.factory.coffee
+++ b/src/app/records/records.factory.coffee
@@ -34,7 +34,6 @@ RecordsFactory = ($location, $q, $http, localStorageService, toastr, $translate)
       return defer.promise
 
     postRecord: (params) ->
-      console.log params.published_at
       defer = $q.defer()
       token = localStorageService.get('access_token')
       login_headers = {

--- a/src/app/records/records.factory.coffee
+++ b/src/app/records/records.factory.coffee
@@ -18,7 +18,23 @@ RecordsFactory = ($location, $q, $http, localStorageService, toastr, $translate)
           return
       return defer.promise
 
+    getRecords: (params) ->
+      defer = $q.defer()
+      token = localStorageService.get('access_token')
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.get host + 'records?date=' + params.published_at, login_headers
+        .success((data) ->
+          defer.resolve data
+          return
+        ).error (data) ->
+          defer.reject data
+          return
+      return defer.promise
+
     postRecord: (params) ->
+      console.log params.published_at
       defer = $q.defer()
       token = localStorageService.get('access_token')
       login_headers = {

--- a/src/assets/i18n/locale-en.json
+++ b/src/assets/i18n/locale-en.json
@@ -48,6 +48,7 @@
     "FINISHED": "Finished"
   },
   "LABELS": {
+    "ADD_20": "(maximum: 20)",
     "BREAKDOWNS": "Breakdowns",
     "FEEDBACK": "Feedback",
     "FEEDBACK_EMAIL": "your Email address",

--- a/src/assets/i18n/locale-ja.json
+++ b/src/assets/i18n/locale-ja.json
@@ -49,6 +49,7 @@
     "FINISHED": "対応済"
   },
   "LABELS": {
+    "ADD_20": "の登録（20件まで）",
     "BREAKDOWNS": "内訳",
     "FEEDBACK": "フィードバック",
     "FEEDBACK_EMAIL": "連絡先メールアドレス",


### PR DESCRIPTION
- 対象の日付の収支を20件まで取得するAPIを追加しました
- 対象の日付に変更したとき、収支一覧を収支登録画面に表示するようにしました
