### PR TITLE
年、月のパラメータがある場合に、対象の年、月の登録収支一覧を返すAPIを追加

### DIFF
--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -10,4 +10,21 @@ class Record < ActiveRecord::Base
                                      greater_than_or_equal_to: 0,
                                      allow_blank: true }
   validates :category, presence: true
+
+  scope :the_day, ->(target_day) { where(published_at: target_day.to_date) }
+  scope :the_year_and_month, lambda { |year, month|
+    start_day = 10.years.ago
+    end_day = 10.years.since
+    if year.present? && month.present?
+      start_day = Date.new(year.to_i, month.to_i, 1)
+      end_day = start_day.end_of_month
+    elsif year.present? && month.blank?
+      start_day = Date.new(year.to_i, 1, 1)
+      end_day = start_day.end_of_year
+    elsif year.blank? && month.present?
+      start_day = Date.new(Time.zone.today.year, month.to_i, 1)
+      end_day = start_day.end_of_month
+    end
+    where(published_at: start_day..end_day)
+  }
 end

--- a/app/models/record/fetcher.rb
+++ b/app/models/record/fetcher.rb
@@ -7,9 +7,10 @@ class Record::Fetcher
   end
 
   def all
-    records = @user.records.order(created_at: :desc)
-    if @params[:date].present?
-      records = records.where(published_at: @params[:date].to_date)
+    records = @user.records.order(published_at: :desc, created_at: :desc)
+    records = records.the_day(@params[:date]) if @params[:date].present?
+    if @params[:year].present? || @params[:month].present?
+      records = records.the_year_and_month(@params[:year], @params[:month])
     end
     @total_count = records.count
     records.offset!(@params[:offset]) if @params[:offset].present?

--- a/spec/requests/records_spec.rb
+++ b/spec/requests/records_spec.rb
@@ -13,36 +13,103 @@ describe 'GET /records', autodoc: true do
     let!(:record1) { create(:record, user: user) }
     let!(:record2) { create(:record, user: user) }
     let!(:record3) do
-      create(:record, user: user, published_at: Time.zone.yesterday)
+      create(:record, user: user, published_at: 1.month.ago)
     end
-    let!(:params) { { date: Time.zone.today } }
 
-    it '200と当日の収支一覧を返すこと' do
-      get '/records', params, login_headers(user)
-      expect(response.status).to eq 200
+    context '日付のパラメータがある場合' do
+      let!(:params) { { date: Time.zone.today } }
 
-      json = {
-        records: [
-          {
-            id: record2.id,
-            charge: record2.charge,
-            category_name: record2.category.name,
-            breakdown_name: record2.breakdown.try(:name),
-            place_name: record2.place.try(:name),
-            memo: record2.memo
-          },
-          {
-            id: record1.id,
-            charge: record1.charge,
-            category_name: record1.category.name,
-            breakdown_name: record1.breakdown.try(:name),
-            place_name: record1.place.try(:name),
-            memo: record1.memo
-          }
-        ],
-        total_count: 2
-      }
-      expect(response.body).to be_json_as(json)
+      it '200と当日の収支一覧を返すこと' do
+        get '/records', params, login_headers(user)
+        expect(response.status).to eq 200
+
+        json = {
+          records: [
+            {
+              id: record2.id,
+              charge: record2.charge,
+              category_name: record2.category.name,
+              breakdown_name: record2.breakdown.try(:name),
+              place_name: record2.place.try(:name),
+              memo: record2.memo
+            },
+            {
+              id: record1.id,
+              charge: record1.charge,
+              category_name: record1.category.name,
+              breakdown_name: record1.breakdown.try(:name),
+              place_name: record1.place.try(:name),
+              memo: record1.memo
+            }
+          ],
+          total_count: 2
+        }
+        expect(response.body).to be_json_as(json)
+      end
+    end
+
+    context '年、月のパラメータがある場合' do
+      let!(:params) { { year: 2016, month: 1.month.ago.month } }
+
+      it '200とその年の収支一覧を返すこと' do
+        get '/records', params, login_headers(user)
+        expect(response.status).to eq 200
+
+        json = {
+          records: [
+            {
+              id: record3.id,
+              charge: record3.charge,
+              category_name: record3.category.name,
+              breakdown_name: record3.breakdown.try(:name),
+              place_name: record3.place.try(:name),
+              memo: record3.memo
+            }
+          ],
+          total_count: 1
+        }
+        expect(response.body).to be_json_as(json)
+      end
+    end
+
+    context '年のパラメータがある場合' do
+      let!(:params) { { year: 2016 } }
+
+      it '200とその年の収支一覧を返すこと' do
+        get '/records', params, login_headers(user)
+        expect(response.status).to eq 200
+
+        json = {
+          records: [
+            {
+              id: record2.id,
+              charge: record2.charge,
+              category_name: record2.category.name,
+              breakdown_name: record2.breakdown.try(:name),
+              place_name: record2.place.try(:name),
+              memo: record2.memo
+            },
+            {
+              id: record1.id,
+              charge: record1.charge,
+              category_name: record1.category.name,
+              breakdown_name: record1.breakdown.try(:name),
+              place_name: record1.place.try(:name),
+              memo: record1.memo
+            },
+            {
+              id: record3.id,
+              charge: record3.charge,
+              category_name: record3.category.name,
+              breakdown_name: record3.breakdown.try(:name),
+              place_name: record3.place.try(:name),
+              memo: record3.memo
+            }
+          ],
+          total_count: 3
+        }
+        expect(response.body).to be_json_as(json)
+      end
     end
   end
 end


### PR DESCRIPTION
- 年（`year`）のパラメータがあった場合、その年の登録情報を返します。
- 月（`month`）のパラメータがあった場合、その月の登録情報を返します。ただし、そのとき`year`は必須となり、なかった場合には今年になります。
