### PR TITLE
「入力する」画面で、カテゴリ選択後、内訳と場所が正しく表示されていない問題を修正

### DIFF
--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -26,7 +26,7 @@ class RecordsController < ApplicationController
   private
 
   def record_params
-    params.permit(:published_at, :charge,
+    params.permit(:published_at, :charge, :memo,
                   :category_id, :breakdown_id, :place_id)
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -29,4 +29,8 @@ class Category < ActiveRecord::Base
   def selected_place?(place_id)
     places.map(&:id).include?(place_id)
   end
+
+  def _payments_name
+    barance_of_payments ? I18n.t('labels.barance_of_payments.income') : I18n.t('labels.barance_of_payments.outgo')
+  end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -31,6 +31,10 @@ class Category < ActiveRecord::Base
   end
 
   def _payments_name
-    barance_of_payments ? I18n.t('labels.barance_of_payments.income') : I18n.t('labels.barance_of_payments.outgo')
+    if barance_of_payments
+      I18n.t('labels.barance_of_payments.income')
+    else
+      I18n.t('labels.barance_of_payments.outgo')
+    end
   end
 end

--- a/app/views/records/new.json.jbuilder
+++ b/app/views/records/new.json.jbuilder
@@ -3,6 +3,7 @@ json.categories do
     json.id category.id
     json.name category.name
     json.barance_of_payments category.barance_of_payments
+    json._payments_name category._payments_name
     json.breakdowns do
       json.array! category.breakdowns do |breakdown|
         json.id breakdown.id

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -18,6 +18,9 @@ ja:
       email_user: メール登録
       twitter_user: Twitter経由
       facebook_user: Facebook経由
+    barance_of_payments:
+      income: 収入
+      outgo: 支出
   user_mailer:
     registration:
       subject: 【PIG BOOK β】アカウント登録のご案内

--- a/spec/requests/records_spec.rb
+++ b/spec/requests/records_spec.rb
@@ -148,6 +148,7 @@ describe 'GET /records/new', autodoc: true do
             id: category.id,
             name: category.name,
             barance_of_payments: category.barance_of_payments,
+            _payments_name: category._payments_name,
             breakdowns: [
               id: breakdown.id,
               name: breakdown.name
@@ -161,6 +162,7 @@ describe 'GET /records/new', autodoc: true do
             id: category2.id,
             name: category2.name,
             barance_of_payments: category2.barance_of_payments,
+            _payments_name: category2._payments_name,
             breakdowns: [],
             places: []
           }

--- a/src/app/records/new.jade
+++ b/src/app/records/new.jade
@@ -58,17 +58,23 @@
           label.control-label.col-sm-2(for='breakdown')
             span(translate='COLUMNS.BREAKDOWN')
           .col-sm-10
-            select.form-control(ng-model='new_record.breakdown_id' name='breakdown_id' ng-disabled='!new_record.category_id')
-              option(ng-value='breakdown.id' ng-repeat='breakdown in new_record.breakdowns')
-                | {{ breakdown.name }}
+            select.form-control(
+              name='breakdown_id'
+              ng-model='new_record.breakdown_id'
+              ng-disabled='!new_record.category_id'
+              ng-options='breakdown.id as breakdown.name for breakdown in new_record.breakdowns'
+            )
         // お店・施設
         .form-group(ng-show='new_record.form_group_place')
           label.control-label.col-sm-2(for='place')
             span(translate='COLUMNS.PLACE')
           .col-sm-10
-            select.form-control(ng-model='new_record.place_id' name='place_id' ng-disabled='!new_record.category_id')
-              option(ng-value='place.id' ng-repeat='place in new_record.places')
-                | {{ place.name }}
+            select.form-control(
+              name='place_id'
+              ng-model='new_record.place_id'
+              ng-disabled='!new_record.category_id'
+              ng-options='place.id as place.name for place in new_record.places'
+             )
         // 金額
         .form-group
           label.control-label.col-sm-2(for='charge')

--- a/src/app/records/new.jade
+++ b/src/app/records/new.jade
@@ -42,13 +42,13 @@
             span(translate='COLUMNS.CATEGORY')
             span.red *
           .col-sm-10
-            select.form-control(ng-model='new_record.category_index_id' name='category_id' required='true' ng-change='new_record.selectCategory(new_record.category_index_id)')
-              optgroup(label="{{ 'LABELS.INCOME' | translate }}" ng-show='income_categories.length != 0')
-                option(ng-value='$index' ng-repeat='category in income_categories = (new_record.categories | filter: { barance_of_payments:true })')
-                  | {{ category.name }}
-              optgroup(label="{{ 'LABELS.OUTGO' | translate }}" ng-show='outgo_categories.length != 0')
-                option(ng-value='$index' ng-repeat='category in outgo_categories = (new_record.categories | filter: { barance_of_payments:false })')
-                  | {{ category.name }}
+            select.form-control(
+              name='category_id'
+              ng-model='new_record.category_id'
+              required='true'
+              ng-change='new_record.selectCategory()'
+              ng-options='category.id as category.name group by category._payments_name for category in new_record.categories'
+            )
             span.errors(ng-messages='newRecordForm.category_id.$error' ng-show='newRecordForm.$submitted && newRecordForm.category_id.$error')
               div(ng-message='required')
                 span.glyphicon.glyphicon-alert#left-icon
@@ -58,7 +58,7 @@
           label.control-label.col-sm-2(for='breakdown')
             span(translate='COLUMNS.BREAKDOWN')
           .col-sm-10
-            select.form-control(ng-model='new_record.breakdown_id' name='breakdown_id' ng-disabled='!new_record.category_index_id')
+            select.form-control(ng-model='new_record.breakdown_id' name='breakdown_id' ng-disabled='!new_record.breakdowns')
               option(ng-value='breakdown.id' ng-repeat='breakdown in new_record.breakdowns')
                 | {{ breakdown.name }}
         // お店・施設
@@ -66,7 +66,7 @@
           label.control-label.col-sm-2(for='place')
             span(translate='COLUMNS.PLACE')
           .col-sm-10
-            select.form-control(ng-model='new_record.place_id' name='place_id' ng-disabled='!new_record.category_index_id')
+            select.form-control(ng-model='new_record.place_id' name='place_id' ng-disabled='!new_record.places')
               option(ng-value='place.id' ng-repeat='place in new_record.places')
                 | {{ place.name }}
         // 金額
@@ -107,7 +107,7 @@
           table.table.table-condensed
             tr(ng-repeat='record in new_record.day_records')
               td
-                a(href='')
+                a(href='' ng-click='new_record.copyRecord($index)')
                   span.glyphicon.glyphicon-arrow-left
               td
                 label.label.label-warning {{ record.category_name }}

--- a/src/app/records/new.jade
+++ b/src/app/records/new.jade
@@ -107,7 +107,7 @@
           table.table.table-condensed
             tr(ng-repeat='record in new_record.day_records')
               td
-                a(href='' ng-click='new_record.copyRecord($index)')
+                a(href='' ng-click='new_record.copyRecord(record)')
                   span.glyphicon.glyphicon-arrow-left
               td
                 label.label.label-warning {{ record.category_name }}

--- a/src/app/records/new.jade
+++ b/src/app/records/new.jade
@@ -58,7 +58,7 @@
           label.control-label.col-sm-2(for='breakdown')
             span(translate='COLUMNS.BREAKDOWN')
           .col-sm-10
-            select.form-control(ng-model='new_record.breakdown_id' name='breakdown_id' ng-disabled='!new_record.breakdowns')
+            select.form-control(ng-model='new_record.breakdown_id' name='breakdown_id' ng-disabled='!new_record.category_id')
               option(ng-value='breakdown.id' ng-repeat='breakdown in new_record.breakdowns')
                 | {{ breakdown.name }}
         // お店・施設
@@ -66,7 +66,7 @@
           label.control-label.col-sm-2(for='place')
             span(translate='COLUMNS.PLACE')
           .col-sm-10
-            select.form-control(ng-model='new_record.place_id' name='place_id' ng-disabled='!new_record.places')
+            select.form-control(ng-model='new_record.place_id' name='place_id' ng-disabled='!new_record.category_id')
               option(ng-value='place.id' ng-repeat='place in new_record.places')
                 | {{ place.name }}
         // 金額

--- a/src/app/records/new_record.controller.coffee
+++ b/src/app/records/new_record.controller.coffee
@@ -56,9 +56,12 @@ NewRecordController = (IndexService, toastr, RecordsFactory, $scope) ->
 
     return
 
-  vm.selectCategory = (category_index_id) ->
-    vm.breakdowns = vm.categories[category_index_id].breakdowns
-    vm.places = vm.categories[category_index_id].places
+  vm.selectCategory = () ->
+    vm.categories.forEach (item, i) ->
+      if item.id == vm.category_id
+        vm.breakdowns = item.breakdowns
+        console.log vm.breakdowns
+        vm.places = item.places
     return
 
   vm.checkSetting = () ->
@@ -81,6 +84,9 @@ NewRecordController = (IndexService, toastr, RecordsFactory, $scope) ->
     ).catch (res) ->
       IndexService.records_loading = false
     return
+
+  vm.copyRecord = (index) ->
+    console.log 'copy'
 
   return
  

--- a/src/app/records/new_record.controller.coffee
+++ b/src/app/records/new_record.controller.coffee
@@ -60,7 +60,6 @@ NewRecordController = (IndexService, toastr, RecordsFactory, $scope) ->
     vm.categories.forEach (item, i) ->
       if item.id == vm.category_id
         vm.breakdowns = item.breakdowns
-        console.log vm.breakdowns
         vm.places = item.places
     return
 
@@ -86,10 +85,12 @@ NewRecordController = (IndexService, toastr, RecordsFactory, $scope) ->
     return
 
   vm.copyRecord = (record) ->
-    console.log vm.categories
     vm.categories.forEach (item, i) ->
       if item.name == record.category_name
         vm.category_id = item.id
+        console.log item
+        vm.breakdowns = item.breakdowns
+        vm.places = item.places
 
   return
  

--- a/src/app/records/new_record.controller.coffee
+++ b/src/app/records/new_record.controller.coffee
@@ -85,12 +85,23 @@ NewRecordController = (IndexService, toastr, RecordsFactory, $scope) ->
     return
 
   vm.copyRecord = (record) ->
-    vm.categories.forEach (item, i) ->
-      if item.name == record.category_name
-        vm.category_id = item.id
-        console.log item
-        vm.breakdowns = item.breakdowns
-        vm.places = item.places
+    vm.categories.forEach (c, i) ->
+      if c.name == record.category_name
+        vm.category_id = c.id
+        vm.breakdowns = c.breakdowns
+        vm.breakdowns.forEach (b, j) ->
+          if b.name == record.breakdown_name
+            vm.breakdown_id = b.id
+        vm.places = c.places
+        vm.places.forEach (p, k) ->
+          if p.name == record.place_name
+            vm.place_id = p.id
+      if record.breakdown_name == null
+        vm.breakdown_id = ''
+      if record.place_name == null
+        vm.place_id = ''
+    vm.charge = record.charge
+    vm.memo = record.memo
 
   return
  

--- a/src/app/records/new_record.controller.coffee
+++ b/src/app/records/new_record.controller.coffee
@@ -85,8 +85,11 @@ NewRecordController = (IndexService, toastr, RecordsFactory, $scope) ->
       IndexService.records_loading = false
     return
 
-  vm.copyRecord = (index) ->
-    console.log 'copy'
+  vm.copyRecord = (record) ->
+    console.log vm.categories
+    vm.categories.forEach (item, i) ->
+      if item.name == record.category_name
+        vm.category_id = item.id
 
   return
  

--- a/src/app/settings/places.jade
+++ b/src/app/settings/places.jade
@@ -63,7 +63,6 @@ script#adding-category(type='text/ng-template')
       a.btn.btn-default(type='submit' translate='BUTTONS.CANCEL' ng-click='adding_category.cancel()')
   .modal-body
     loading-directive(target='modal')
-    {{ filtered_categories.length }}
     select.form-control(ng-model='adding_category.category_id' ng-show='adding_category.categories')
       optgroup(label="{{ 'LABELS.INCOME' | translate }}" ng-show='income_categories.length != 0')
         option(ng-value='category.id' ng-repeat='category in income_categories = (adding_category.categories | filter: { selected_place:false, barance_of_payments:true })')


### PR DESCRIPTION
- 入力で、備考が保存できていなかった問題を解消しました
- カテゴリ選択後、内訳と場所が表示される部分を`ng-options`を使ってリファクタリングしました
- 各カテゴリの値について「収入」「支出」の文字列を返すようにしました
- 「入力する」画面に表示される一覧の「←」クリック時に、入力フォームに値をコピーするようにしました
- 不要な行を削除しました
