### PR TITLE
メッセージとお知らせを同時に取得＆最近の入力一覧を取得

### DIFF
--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,0 +1,8 @@
+class MypagesController < ApplicationController
+  before_action :authenticate
+
+  def show
+    @notices = Notice::Fetcher.all(params: params).published
+    @messages = Message::Fetcher.all(params: params, user: current_user)
+  end
+end

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -28,4 +28,11 @@ class Record < ActiveRecord::Base
     end
     where(published_at: start_day..end_day)
   }
+  scope :order_type, lambda { |sort_type|
+    if sort_type == 'lately'
+      order(created_at: :desc)
+    else
+      order(published_at: :desc, created_at: :desc)
+    end
+  }
 end

--- a/app/models/record/fetcher.rb
+++ b/app/models/record/fetcher.rb
@@ -7,7 +7,7 @@ class Record::Fetcher
   end
 
   def all
-    records = @user.records.order(published_at: :desc, created_at: :desc)
+    records = @user.records.order_type(@params[:sort])
     records = records.the_day(@params[:date]) if @params[:date].present?
     if @params[:year].present? || @params[:month].present?
       records = records.the_year_and_month(@params[:year], @params[:month])

--- a/app/views/mypages/show.json.jbuilder
+++ b/app/views/mypages/show.json.jbuilder
@@ -1,0 +1,17 @@
+json.notices do
+  json.array! @notices do |notice|
+    json.id notice.id
+    json.title notice.title
+    json.content notice.content
+    json.post_at notice.post_at
+  end
+end
+
+json.messages do
+  json.array! @messages do |message|
+    json.id message.id
+    json.content message.content
+    json.read message.read
+    json.created_at I18n.l(message.created_at)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,4 +43,5 @@ Rails.application.routes.draw do
     patch :set_display
   end
   resource :feedback, only: %i(create)
+  resource :mypage, only: %i(show), on: :collection
 end

--- a/spec/requests/mypage_spec.rb
+++ b/spec/requests/mypage_spec.rb
@@ -1,5 +1,62 @@
 require 'rails_helper'
 
+describe 'GET /mypage', autodoc: true do
+  context 'ログインしていない場合' do
+    it '401が返ってくること' do
+      get '/user'
+      expect(response.status).to eq 401
+    end
+  end
+
+  context 'ユーザーにお知らせとメッセージがある場合' do
+    let!(:user) { create(:email_user, :registered) }
+    let!(:user2) { create(:email_user, :registered) }
+    let!(:notice1) { create(:notice, post_at: Time.zone.today) }
+    let!(:notice2) { create(:notice, post_at: Time.zone.yesterday) }
+    let!(:notice3) { create(:notice, post_at: Time.zone.tomorrow) }
+    let!(:message1) { create(:message, user: user, read: true) }
+    let!(:message2) { create(:message, user: user2) }
+    let!(:message3) { create(:message, user: user) }
+
+    it '200とお知らせ情報、メッセージ情報を返すこと' do
+      get '/mypage', '', login_headers(user)
+      expect(response.status).to eq 200
+
+      json = {
+        notices: [
+          {
+            id: notice1.id,
+            title: notice1.title,
+            content: notice1.content,
+            post_at: notice1.post_at.strftime('%Y-%m-%d')
+          },
+          {
+            id: notice2.id,
+            title: notice2.title,
+            content: notice2.content,
+            post_at: notice2.post_at.strftime('%Y-%m-%d')
+          }
+        ],
+        messages: [
+          {
+            id: message3.id,
+            content: message3.content,
+            read: false,
+            created_at: I18n.l(message3.created_at)
+          },
+          {
+            id: message1.id,
+            content: message1.content,
+            read: true,
+            created_at: I18n.l(message1.created_at)
+          }
+        ]
+      }
+      expect(response.body).to be_json_as(json)
+    end
+  end
+end
+
 describe 'GET /notices', autodoc: true do
   context 'ログインしていない場合' do
     it '401が返ってくること' do

--- a/src/app/components/loading.jade
+++ b/src/app/components/loading.jade
@@ -1,5 +1,3 @@
 img(ng-src='assets/images/loader.gif' width='60px' ng-show='loading.loading' alt='loading.target' ng-if='loading.target == undefined')
 img(ng-src='assets/images/loader.gif' width='60px' ng-show='loading.modal_loading' alt='loading.target' ng-if="loading.target == 'modal'")
-img(ng-src='assets/images/loader.gif' width='60px' ng-show='loading.notice_loading' alt='loading.target' ng-if="loading.target == 'notice'")
-img(ng-src='assets/images/loader.gif' width='60px' ng-show='loading.message_loading' alt='loading.target' ng-if="loading.target == 'message'")
 img(ng-src='assets/images/loader.gif' width='60px' ng-show='loading.records_loading' alt='loading.target' ng-if="loading.target == 'records'")

--- a/src/app/index.service.coffee
+++ b/src/app/index.service.coffee
@@ -5,8 +5,6 @@ IndexService = () ->
   vm.current_user = undefined
   vm.loading = false
   vm.modal_loading = false
-  vm.notice_loading = false
-  vm.message_loading = false
   vm.records_loading = false
 
   return

--- a/src/app/user/mypage.controller.coffee
+++ b/src/app/user/mypage.controller.coffee
@@ -1,22 +1,15 @@
-MypageController = (UserFactory, $modal, IndexService) ->
+MypageController = (UserFactory, IndexService) ->
   'ngInject'
   vm = this
-  vm.offset = 0
 
-  IndexService.notice_loading = true
-  UserFactory.getNotices(vm.offset).then((res) ->
+  IndexService.loading = true
+  UserFactory.getMypage().then((res) ->
     vm.notices = res.notices
-    IndexService.notice_loading = false
-  ).catch (res) ->
-    IndexService.notice_loading = false
-
-  IndexService.message_loading = true
-  UserFactory.getMessages(vm.offset).then((res) ->
     vm.messages = res.messages
-    IndexService.message_loading = false
+    IndexService.loading = false
   ).catch (res) ->
-    IndexService.message_loading = false
- 
+    IndexService.loading = false
+
   return
 
 angular.module 'newAccountBook'

--- a/src/app/user/mypage.jade
+++ b/src/app/user/mypage.jade
@@ -9,7 +9,7 @@
         span.glyphicon.glyphicon-film#left-icon
         span(translate='TITLES.NOTICE_LIST')
       .panel-body
-        loading-directive(target='notice')
+        loading-directive
         ul.list
           li(ng-repeat='notice in mypage.notices | limitTo:5')
             span#post_at {{ notice.post_at }}
@@ -21,7 +21,7 @@
         span.glyphicon.glyphicon-envelope#left-icon
         span(translate='TITLES.MESSAGE_LIST')
       .panel-body
-        loading-directive(target='message')
+        loading-directive
         ul.list
           li(ng-show='mypage.messages.length == 0')
             span#post_at メッセージはありません

--- a/src/app/user/user.factory.coffee
+++ b/src/app/user/user.factory.coffee
@@ -18,6 +18,21 @@ UserFactory = ($location, $q, $http, localStorageService, toastr, $translate, In
           return
       return defer.promise
 
+    getMypage: (offset) ->
+      defer = $q.defer()
+      token = localStorageService.get('access_token')
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.get host + 'mypage', login_headers
+        .success((data) ->
+          defer.resolve data
+          return
+        ).error (data) ->
+          defer.reject data
+          return
+      return defer.promise
+
     getNotices: (offset) ->
       defer = $q.defer()
       token = localStorageService.get('access_token')


### PR DESCRIPTION
- メッセージとお知らせを同時に取得できるように変更しました
- あるパラメータを付加することで、入力一覧を作成日順で返せるようにAPIを修正しました
