### PR TITLE
収支を編集する画面を追加するための用意で、APIを追加する

### DIFF
--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -7,6 +7,10 @@ class RecordsController < ApplicationController
     @total_count = fetcher.total_count
   end
 
+  def show
+    @record = current_user.records.find(params[:id])
+  end
+
   def new
     @user = current_user
     @categories = current_user.categories
@@ -21,6 +25,12 @@ class RecordsController < ApplicationController
     else
       render_error @record
     end
+  end
+
+  def edit
+    @user = current_user
+    @categories = current_user.categories
+                              .order(:position)
   end
 
   def update

--- a/app/views/records/edit.json.jbuilder
+++ b/app/views/records/edit.json.jbuilder
@@ -1,0 +1,26 @@
+json.categories do
+  json.array! @categories do |category|
+    json.id category.id
+    json.name category.name
+    json.barance_of_payments category.barance_of_payments
+    json._payments_name category._payments_name
+    json.breakdowns do
+      json.array! category.breakdowns do |breakdown|
+        json.id breakdown.id
+        json.name breakdown.name
+      end
+    end
+    json.places do
+      json.array! category.places do |place|
+        json.id place.id
+        json.name place.name
+      end
+    end
+  end
+end
+
+json.user do
+  json.breakdown_field @user.breakdown_field
+  json.place_field @user.place_field
+  json.memo_field @user.memo_field
+end

--- a/app/views/records/show.json.jbuilder
+++ b/app/views/records/show.json.jbuilder
@@ -1,0 +1,7 @@
+json.id @record.id
+json.published_at @record.published_at
+json.charge @record.charge
+json.category_name @record.category.name
+json.breakdown_name @record.breakdown.try(:name)
+json.place_name @record.place.try(:name)
+json.memo @record.memo

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,7 +37,7 @@ Rails.application.routes.draw do
   resources :places, only: %i(index create update destroy) do
     resources :categories, only: %i(index update destroy), module: :place
   end
-  resources :records, only: %i(index new create update)
+  resources :records, only: %i(index show new create edit update)
 
   resource :user, only: %i(show update) do
     patch :set_display


### PR DESCRIPTION
- 編集画面（モーダル）を表示するために、カテゴリ一覧とそれに紐づく内訳一覧、場所一覧を返すAPIを追加しました
- 収支の一つを返すAPIを追加しました
