### PR TITLE
「入力する」「マイページトップ」から収支の編集ができるようにする

### DIFF
--- a/src/app/records/new.jade
+++ b/src/app/records/new.jade
@@ -128,5 +128,5 @@
                 label.label.label-primary {{ record.place_name }}
               td ¥ {{ record.charge | number }}
               td
-                a(href='')
+                a(href='' ng-click='new_record.showRecord($index)')
                   span.glyphicon.glyphicon-info-sign

--- a/src/app/records/new_record.controller.coffee
+++ b/src/app/records/new_record.controller.coffee
@@ -1,4 +1,4 @@
-NewRecordController = (IndexService, toastr, RecordsFactory, $scope) ->
+NewRecordController = (IndexService, toastr, RecordsFactory, $scope, $modal) ->
   'ngInject'
   vm = this
 
@@ -96,6 +96,19 @@ NewRecordController = (IndexService, toastr, RecordsFactory, $scope) ->
   vm.setToday = () ->
     vm.published_at = new Date()
     getRecordsWithDate()
+
+  # モーダル
+  vm.showRecord = (index) ->
+    record = vm.day_records[index]
+    modalInstance = $modal.open(
+      templateUrl: 'app/records/modals/record.html'
+      controller: 'EditRecordController'
+      controllerAs: 'edit_record'
+      resolve: { record_id: record.id }
+      backdrop: 'static'
+    )
+    modalInstance.result.then () ->
+      getRecordsWithDate() # TODO: 対象のレコードのみ更新
 
   return
  

--- a/src/app/records/new_record.controller.coffee
+++ b/src/app/records/new_record.controller.coffee
@@ -108,7 +108,8 @@ NewRecordController = (IndexService, toastr, RecordsFactory, $scope, $modal) ->
       backdrop: 'static'
     )
     modalInstance.result.then () ->
-      getRecordsWithDate() # TODO: 対象のレコードのみ更新
+      RecordsFactory.getRecord(record.id).then (res) ->
+        vm.day_records[index] = res
 
   return
  

--- a/src/app/records/records.controller.coffee
+++ b/src/app/records/records.controller.coffee
@@ -91,7 +91,8 @@ RecordsController = ($filter, IndexService , RecordsFactory, localStorageService
       backdrop: 'static'
     )
     modalInstance.result.then () ->
-      getRecordsWithDate() # TODO: 対象のレコードのみ更新
+      RecordsFactory.getRecord(record.id).then (res) ->
+        vm.records[index] = res
 
     return
 

--- a/src/app/user/mypage.controller.coffee
+++ b/src/app/user/mypage.controller.coffee
@@ -1,4 +1,4 @@
-MypageController = (UserFactory, IndexService) ->
+MypageController = (UserFactory, IndexService, $modal, RecordsFactory) ->
   'ngInject'
   vm = this
 
@@ -10,6 +10,22 @@ MypageController = (UserFactory, IndexService) ->
     IndexService.loading = false
   ).catch (res) ->
     IndexService.loading = false
+
+  # モーダル
+  vm.showRecord = (index) ->
+    record = vm.records[index]
+    modalInstance = $modal.open(
+      templateUrl: 'app/records/modals/record.html'
+      controller: 'EditRecordController'
+      controllerAs: 'edit_record'
+      resolve: { record_id: record.id }
+      backdrop: 'static'
+    )
+    modalInstance.result.then () ->
+      RecordsFactory.getRecord(record.id).then (res) ->
+        vm.records[index] = res
+      
+    return
 
   return
 

--- a/src/app/user/mypage.jade
+++ b/src/app/user/mypage.jade
@@ -21,7 +21,7 @@
               label.label.label-primary {{ record.place_name }}
             td ¥ {{ record.charge | number }}
             td
-              a(href='')
+              a(href='' ng-click='mypage.showRecord($index)')
                 span.glyphicon.glyphicon-info-sign
 
   // お知らせ


### PR DESCRIPTION
- 「入力する」「マイページトップ」の画面にある収支一覧の「i」アイコンをクリックすることで、収支の情報を確認できるモーダルを開くようにしました
- 「編集」ボタンからの「更新する」ボタンで、対象の収支を更新できるようにしました。
