### PR TITLE
登録されているラベルを取得するapiを追加

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,0 +1,7 @@
+class TagsController < ApplicationController
+  before_action :authenticate
+
+  def index
+    @tags = current_user.tags
+  end
+end

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -3,6 +3,8 @@ class Record < ActiveRecord::Base
   belongs_to :category
   belongs_to :breakdown
   belongs_to :place
+  has_many :tagged_records
+  has_many :tags, through: :tagged_records
 
   validates :published_at, presence: true
   validates :charge, presence: true,

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,6 @@
+class Tag < ActiveRecord::Base
+  belongs_to :user
+
+  has_many :tagged_records
+  has_many :records, through: :tagged_records
+end

--- a/app/models/tagged_record.rb
+++ b/app/models/tagged_record.rb
@@ -1,0 +1,4 @@
+class TaggedRecord < ActiveRecord::Base
+  belongs_to :tag
+  belongs_to :record
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ActiveRecord::Base
   has_many :places
   has_many :messages
   has_many :records
+  has_many :tags
 
   enum status: { registered: 2, inactive: 1 }
 

--- a/app/views/tags/index.json.jbuilder
+++ b/app/views/tags/index.json.jbuilder
@@ -1,0 +1,6 @@
+json.tags do
+  json.array! @tags do |tag|
+    json.id tag.id
+    json.name tag.name
+  end
+end

--- a/app/views/tags/index.json.jbuilder
+++ b/app/views/tags/index.json.jbuilder
@@ -1,6 +1,7 @@
 json.tags do
   json.array! @tags do |tag|
     json.id tag.id
+    json.color_code tag.color_code
     json.name tag.name
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Rails.application.routes.draw do
     resources :categories, only: %i(index update destroy), module: :place
   end
   resources :records, only: %i(index show new create edit update destroy)
+  resources :tags, only: %i(index)
 
   resource :user, only: %i(show update) do
     patch :set_display

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -2,6 +2,6 @@ FactoryGirl.define do
   factory :tag do
     user
     sequence(:name) { |i| "ラベル#{i}" }
-    color_code { format('%06x', (rand * 0xffffff)) }
+    color_code { '#' + format('%06x', (rand * 0xffffff)) }
   end
 end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :tag do
+    user
+    sequence(:name) { |i| "ラベル#{i}" }
+    color_code { format('%06x', (rand * 0xffffff)) }
+  end
+end

--- a/spec/models/record_spec.rb
+++ b/spec/models/record_spec.rb
@@ -9,4 +9,7 @@ RSpec.describe Record, type: :model do
   it { is_expected.to validate_presence_of(:published_at) }
   it { is_expected.to validate_presence_of(:charge) }
   it { is_expected.to validate_presence_of(:category) }
+
+  it { is_expected.to have_many(:tagged_records) }
+  it { is_expected.to have_many(:tags).through(:tagged_records) }
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -2,4 +2,6 @@ require 'rails_helper'
 
 RSpec.describe Tag, type: :model do
   it { is_expected.to belong_to(:user) }
+  it { is_expected.to have_many(:tagged_records) }
+  it { is_expected.to have_many(:records).through(:tagged_records) }
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Tag, type: :model do
+  it { is_expected.to belong_to(:user) }
+end

--- a/spec/models/tagged_record_spec.rb
+++ b/spec/models/tagged_record_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe TaggedRecord, type: :model do
+  it { is_expected.to belong_to(:record) }
+  it { is_expected.to belong_to(:tag) }
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,4 +6,5 @@ RSpec.describe User, type: :model do
   it { is_expected.to have_many(:places) }
   it { is_expected.to have_many(:messages) }
   it { is_expected.to have_many(:records) }
+  it { is_expected.to have_many(:tags) }
 end

--- a/spec/requests/tags_spec.rb
+++ b/spec/requests/tags_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe 'GET /tags', autodoc: true do
+  context 'ログインしていない場合' do
+    it '401が返ってくること' do
+      get '/tags'
+      expect(response.status).to eq 401
+    end
+  end
+
+  context 'メールアドレスのユーザーがログインしている場合' do
+    let!(:user) { create(:email_user, :registered) }
+    let!(:tag1) { create(:tag, user: user) }
+    let!(:tag2) { create(:tag, user: user) }
+
+    it '200とラベル一覧を返すこと' do
+      get '/tags', '', login_headers(user)
+      expect(response.status).to eq 200
+
+      json = {
+        tags: [
+          {
+            id: tag1.id,
+            name: tag1.name
+          },
+          {
+            id: tag2.id,
+            name: tag2.name
+          }
+        ]
+      }
+      expect(response.body).to be_json_as(json)
+    end
+  end
+end

--- a/spec/requests/tags_spec.rb
+++ b/spec/requests/tags_spec.rb
@@ -21,10 +21,12 @@ describe 'GET /tags', autodoc: true do
         tags: [
           {
             id: tag1.id,
+            color_code: tag1.color_code,
             name: tag1.name
           },
           {
             id: tag2.id,
+            color_code: tag2.color_code,
             name: tag2.name
           }
         ]


### PR DESCRIPTION
- 収支（レコード）に紐づくラベルという位置付けで、テーブルの関係を設定しました
- ユーザーが登録しているラベル一覧が帰ってくるAPIを追加しました
