### PR TITLE
ラベルの表示設定を登録、取得＆ラベルのデザインを修正

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,6 +28,6 @@ class UsersController < ApplicationController
   end
 
   def setting_params
-    params.permit(:breakdown_field, :place_field, :memo_field)
+    params.permit(:breakdown_field, :place_field, :tag_field, :memo_field)
   end
 end

--- a/app/views/records/edit.json.jbuilder
+++ b/app/views/records/edit.json.jbuilder
@@ -22,6 +22,7 @@ end
 json.user do
   json.breakdown_field @user.breakdown_field
   json.place_field @user.place_field
+  json.tag_field @user.tag_field
   json.memo_field @user.memo_field
 end
 

--- a/app/views/records/new.json.jbuilder
+++ b/app/views/records/new.json.jbuilder
@@ -22,5 +22,6 @@ end
 json.user do
   json.breakdown_field @user.breakdown_field
   json.place_field @user.place_field
+  json.tag_field @user.tag_field
   json.memo_field @user.memo_field
 end

--- a/db/migrate/20160407042527_add_tag_field_to_users.rb
+++ b/db/migrate/20160407042527_add_tag_field_to_users.rb
@@ -1,0 +1,5 @@
+class AddTagFieldToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :tag_field, :boolean
+  end
+end

--- a/db/migrate/20160407070734_change_column_default_to_users.rb
+++ b/db/migrate/20160407070734_change_column_default_to_users.rb
@@ -1,0 +1,5 @@
+class ChangeColumnDefaultToUsers < ActiveRecord::Migration
+  def change
+    change_column_default :users, :tag_field, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160407042527) do
+ActiveRecord::Schema.define(version: 20160407070734) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -208,7 +208,7 @@ ActiveRecord::Schema.define(version: 20160407042527) do
     t.boolean  "breakdown_field",        default: true
     t.boolean  "place_field",            default: true
     t.boolean  "memo_field",             default: true
-    t.boolean  "tag_field"
+    t.boolean  "tag_field",              default: true
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160326114450) do
+ActiveRecord::Schema.define(version: 20160407042527) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -208,7 +208,7 @@ ActiveRecord::Schema.define(version: 20160326114450) do
     t.boolean  "breakdown_field",        default: true
     t.boolean  "place_field",            default: true
     t.boolean  "memo_field",             default: true
-    t.integer  "date_setting"
+    t.boolean  "tag_field"
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree

--- a/spec/requests/records_spec.rb
+++ b/spec/requests/records_spec.rb
@@ -200,6 +200,7 @@ describe 'GET /records/new', autodoc: true do
         user: {
           breakdown_field: true,
           place_field: true,
+          tag_field: true,
           memo_field: true
         }
       }
@@ -308,6 +309,7 @@ describe 'GET /records/:id/edit', autodoc: true do
         user: {
           breakdown_field: true,
           place_field: true,
+          tag_field: true,
           memo_field: true
         },
         record: {

--- a/src/app/index.scss
+++ b/src/app/index.scss
@@ -279,3 +279,7 @@ body {
   font-weight: normal;
   font-style: normal;
 }
+
+//tags-input .tags .input {
+//  background-color: red;
+//}

--- a/src/app/records/new.jade
+++ b/src/app/records/new.jade
@@ -89,7 +89,8 @@
                        display-property='name'
                        placeholder="{{ 'MESSAGES.TAG_PLACEHOLDER' | translate }}"
                        replace-spaces-with-dashes='false'
-                       min-length='1')
+                       min-length='1'
+                       template='tag-template')
               auto-complete(source='new_record.loadTags($query)'
                             min-length='0'
                             max-results-to-show='32'
@@ -153,6 +154,12 @@
               td
                 a(href='' ng-click='new_record.destroyRecord($index)')
                   span.glyphicon.glyphicon-trash
+
+script#tag-template(type='text/ng-template')
+  .tag-template
+    span.glyphicon.glyphicon-bookmark#left-icon(ng-if='data.color_code' ng-style="{color:data.color_code}")
+    span.ng-binding.ng-scope {{ data.name }}
+    a.remove-button.ng-binding.ng-scope(ng-click='$removeTag()') ×
 
 script#autocomplete-template(type='text/ng-template')
   .autocomplete-template

--- a/src/app/records/new.jade
+++ b/src/app/records/new.jade
@@ -17,6 +17,9 @@
           input(type='checkbox' ng-model='new_record.place_field' ng-change='new_record.checkSetting()')
           span {{ 'COLUMNS.PLACE' | translate }}
         label.checkbox-inline
+          input(type='checkbox' ng-model='new_record.tag_field' ng-change='new_record.checkSetting()')
+          span {{ 'COLUMNS.TAG' | translate }}
+        label.checkbox-inline
           input(type='checkbox' ng-model='new_record.memo_field' ng-change='new_record.checkSetting()')
           span {{ 'COLUMNS.MEMO' | translate }}
       hr(ng-show='new_record.settings')
@@ -78,17 +81,18 @@
               ng-options='place.id as place.name for place in new_record.places'
              )
         // ラベル
-        .form-group(ng-show='new_record.form_group_place')
+        .form-group(ng-show='new_record.form_group_tag')
           label.control-label.col-sm-2(for='tag')
             span(translate='COLUMNS.TAG')
           .col-sm-10
             tags-input(ng-model='new_record.tags'
                        display-property='name'
-                       placeholder=''
+                       placeholder="{{ 'MESSAGES.TAG_PLACEHOLDER' | translate }}"
                        replace-spaces-with-dashes='false'
                        min-length='1')
               auto-complete(source='new_record.loadTags($query)'
                             min-length='0'
+                            max-results-to-show='32'
                             load-on-focus='true'
                             load-on-empty='true')
             span.glyphicon.glyphicon-question-sign.blue(tooltip="{{ 'TOOLTIPS.TAGS_QUESTION' | translate }}")

--- a/src/app/records/new.jade
+++ b/src/app/records/new.jade
@@ -94,7 +94,8 @@
                             min-length='0'
                             max-results-to-show='32'
                             load-on-focus='true'
-                            load-on-empty='true')
+                            load-on-empty='true'
+                            template='autocomplete-template')
             span.glyphicon.glyphicon-question-sign.blue(tooltip="{{ 'TOOLTIPS.TAGS_QUESTION' | translate }}")
         // 金額
         .form-group
@@ -152,3 +153,10 @@
               td
                 a(href='' ng-click='new_record.destroyRecord($index)')
                   span.glyphicon.glyphicon-trash
+
+script#autocomplete-template(type='text/ng-template')
+  .autocomplete-template
+    .left-panel
+      span.glyphicon.glyphicon-bookmark#left-icon(ng-style="{color:data.color_code}")
+    .right-panel
+      span {{ data.name }}

--- a/src/app/records/new_record.controller.coffee
+++ b/src/app/records/new_record.controller.coffee
@@ -10,9 +10,11 @@ NewRecordController = (IndexService, toastr, RecordsFactory, $scope, $modal, Set
     vm.categories = res.categories
     vm.breakdown_field = res.user.breakdown_field
     vm.place_field = res.user.place_field
+    vm.tag_field = res.user.tag_field
     vm.memo_field = res.user.memo_field
     vm.form_group_breakdown = vm.breakdown_field
     vm.form_group_place = vm.place_field
+    vm.form_group_tag = vm.tag_field
     vm.form_group_memo = vm.memo_field
     IndexService.loading = false
   ).catch (res) ->
@@ -64,10 +66,12 @@ NewRecordController = (IndexService, toastr, RecordsFactory, $scope, $modal, Set
     params =
       breakdown_field: vm.breakdown_field
       place_field: vm.place_field
+      tag_field: vm.tag_field
       memo_field: vm.memo_field
     RecordsFactory.patchSettings(params).then (res) ->
       vm.form_group_breakdown = vm.breakdown_field
       vm.form_group_place = vm.place_field
+      vm.form_group_tag = vm.tag_field
       vm.form_group_memo = vm.memo_field
     return
 

--- a/src/app/records/tags.scss
+++ b/src/app/records/tags.scss
@@ -47,3 +47,12 @@ auto-complete .autocomplete .suggestion-item.selected {
 auto-complete .autocomplete .suggestion-item {
   font-size: 12px;
 }
+
+auto-complete .autocomplete-template .right-panel span {
+  vertical-align: middle;
+}
+
+auto-complete .autocomplete-template .left-panel {
+  margin-left: 5px;
+  float: left;
+}

--- a/src/app/records/tags.scss
+++ b/src/app/records/tags.scss
@@ -1,0 +1,49 @@
+tags-input .tags {
+  background-color: #fff;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+}
+
+tags-input .tags .tag-item.selected {
+  border-color: $red;
+  background: #fff;
+  color: $red;
+}
+
+tags-input .tags .tag-item.selected .remove-button {
+  color: lighten($red, 20%);
+}
+
+tags-input .tags .tag-item .remove-button:active {
+  color: lighten($red, 20%);
+}
+
+tags-input .tags .tag-item {
+  border-color: $green;
+  border-radius: 4px;
+  color: #fff;
+}
+
+tags-input .tags .tag-item {
+  background: #fff;
+  color: $green;
+}
+
+tags-input .tags .tag-item .remove-button {
+  color: lighten($green, 20%);
+}
+
+auto-complete .autocomplete {
+  border-radius: 4px;
+}
+
+auto-complete .autocomplete .suggestion-item.selected {
+  color: #262626;
+  background-color: #f6f6f6;
+}
+
+auto-complete .autocomplete .suggestion-item {
+  font-size: 12px;
+}

--- a/src/assets/i18n/locale-en.json
+++ b/src/assets/i18n/locale-en.json
@@ -135,6 +135,7 @@
     "SEND_MAIL": "Send a Mail",
     "SEND_MESSAGE": "Send a Message",
     "SEND_MESSAGE_TO_ADMIN": "Send your message",
+    "TAG_PLACEHOLDER": "Add a tag",
     "UPDATE_PASSWORD": "Your Password has been changed",
     "NOT_FOUND_EMAIL": "Email already registered or Not yet signed up for registration",
     "NOT_FOUND_PAGE": "Not Found the Page",

--- a/src/assets/i18n/locale-ja.json
+++ b/src/assets/i18n/locale-ja.json
@@ -136,6 +136,7 @@
     "SEND_MAIL": "メールを送信しました",
     "SEND_MESSAGE": "メッセージを送信しました",
     "SEND_MESSAGE_TO_ADMIN": "管理者にメッセージを送信しました",
+    "TAG_PLACEHOLDER": "ラベルを追加・選択",
     "UPDATE_PASSWORD": "パスワードを変更しました",
     "NOT_FOUND_EMAIL": "メールアドレスがすでに本登録されているか、登録されていないメールアドレスです",
     "NOT_FOUND_PAGE": "お探しのページは見つかりません。URLをご確認ください。",


### PR DESCRIPTION
- 「入力する」画面で、ラベルの表示設定を取得、チェック項目として表示しました
- チェックすると表示、非表示を切り替えるようにしました
- チェックするとその情報をサーバーに登録しにいくようにしました
- 「入力する」画面のラベルのデザインを変更しました
- 「入力する」画面のラベルの一覧のデザインを修正しました
