### PR TITLE
日付の編集後、「今日のリスト」が更新されない問題を修正

### DIFF
--- a/src/app/records/new_record.controller.coffee
+++ b/src/app/records/new_record.controller.coffee
@@ -128,8 +128,7 @@ NewRecordController = (IndexService, toastr, RecordsFactory, $scope, $modal, Set
       backdrop: 'static'
     )
     modalInstance.result.then () ->
-      RecordsFactory.getRecord(record.id).then (res) ->
-        vm.day_records[index] = res
+      getRecordsWithDate()
 
   # 削除アイコン -> モーダル
   vm.destroyRecord = (index) ->


### PR DESCRIPTION
日付を編集してモーダルを閉じた場合、対象のレコードが残ってしまう問題を修正しました

対象のレコードのみを更新するようにしていたため、日付が変わると表示されなくなることを考慮していなかったことが原因です。
