### PR TITLE
カテゴリに紐づく収支が存在していた場合、削除できないように修正

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -24,6 +24,10 @@ class Category < ActiveRecord::Base
       errors[:base] << I18n.t('errors.messages.categories.destroy_breakdowns')
       false
     end
+    if records.any?
+      errors[:base] << I18n.t('errors.messages.categories.destroy_records')
+      false
+    end
   end
 
   def selected_place?(place_id)

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -22,11 +22,11 @@ class Category < ActiveRecord::Base
   def confirm_contents
     if breakdowns.any?
       errors[:base] << I18n.t('errors.messages.categories.destroy_breakdowns')
-      false
+      return false
     end
     if records.any?
       errors[:base] << I18n.t('errors.messages.categories.destroy_records')
-      false
+      return false
     end
   end
 

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -1,4 +1,6 @@
 class Record < ActiveRecord::Base
+  counter_culture :category
+
   belongs_to :user
   belongs_to :category
   belongs_to :breakdown

--- a/app/views/categories/index.json.jbuilder
+++ b/app/views/categories/index.json.jbuilder
@@ -5,5 +5,6 @@ json.categories do
     json.barance_of_payments category.barance_of_payments
     json.breakdowns_count category.breakdowns_count
     json.places_count category.places_count
+    json.records_count category.records_count
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -8,6 +8,7 @@ ja:
       categories:
         failed_to_sort: 並び替えに失敗しました。
         destroy_breakdowns: 登録した内訳を削除してから削除してください
+        destroy_records: 登録した収支を削除してから削除してください
       too_long: の作成上限は%{count}件です
   labels:
     administrator: 管理者

--- a/db/migrate/20160414043428_add_records_count_to_categories.rb
+++ b/db/migrate/20160414043428_add_records_count_to_categories.rb
@@ -1,0 +1,9 @@
+class AddRecordsCountToCategories < ActiveRecord::Migration
+  def self.up
+    add_column :categories, :records_count, :integer, null: false, default: 0
+  end
+
+  def self.down
+    remove_column :categories, :records_count
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160413090937) do
+ActiveRecord::Schema.define(version: 20160414043428) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 20160413090937) do
     t.integer  "position"
     t.integer  "breakdowns_count",    default: 0, null: false
     t.integer  "places_count",        default: 0, null: false
+    t.integer  "records_count",       default: 0, null: false
   end
 
   add_index "categories", ["user_id"], name: "index_categories_on_user_id", using: :btree

--- a/spec/requests/categories_spec.rb
+++ b/spec/requests/categories_spec.rb
@@ -28,14 +28,16 @@ describe 'GET /categories', autodoc: true do
             name: category.name,
             barance_of_payments: category.barance_of_payments,
             breakdowns_count: category.breakdowns.count,
-            places_count: 1
+            places_count: 1,
+            records_count: 0
           },
           {
             id: category2.id,
             name: category2.name,
             barance_of_payments: category2.barance_of_payments,
             breakdowns_count: category2.breakdowns.count,
-            places_count: 0
+            places_count: 0,
+            records_count: 0
           }
         ]
       }

--- a/spec/requests/categories_spec.rb
+++ b/spec/requests/categories_spec.rb
@@ -175,6 +175,21 @@ describe 'DELETE /categories/:id', autodoc: true do
     end
   end
 
+  context '削除対象のカテゴリが複数の収支を登録していた場合' do
+    before do
+      create(:record, category: category)
+    end
+
+    it '422とエラーメッセージが返ってくること' do
+      delete "/categories/#{category.id}", '', login_headers(user)
+      expect(response.status).to eq 422
+      json = {
+        error_messages: ['登録した収支を削除してから削除してください']
+      }
+      expect(response.body).to be_json_as(json)
+    end
+  end
+
   context '削除対象のカテゴリが複数の場所を登録していた場合' do
     let!(:place) { create(:place, user: user) }
     before do

--- a/spec/requests/records_spec.rb
+++ b/spec/requests/records_spec.rb
@@ -176,11 +176,11 @@ describe 'GET /records/new', autodoc: true do
     let!(:category2) { create(:category, user: user) }
     let!(:breakdown) { create(:breakdown, category: category) }
     let!(:place) { create(:place, user: user) }
+    let!(:categorize_place) do
+      create(:categorize_place, category: category, place: place)
+    end
 
     it '200とカテゴリ一覧を返すこと' do
-      category.places << place
-      category.save
-
       get '/records/new', '', login_headers(user)
       expect(response.status).to eq 200
 
@@ -283,6 +283,9 @@ describe 'GET /records/:id/edit', autodoc: true do
   let!(:breakdown) { create(:breakdown, category: category) }
   let!(:place) { create(:place, user: user) }
   let!(:record) { create(:record, user: user, category: category) }
+  let!(:categorize_place) do
+    create(:categorize_place, category: category, place: place)
+  end
 
   context 'ログインしていない場合' do
     it '401が返ってくること' do
@@ -293,9 +296,6 @@ describe 'GET /records/:id/edit', autodoc: true do
 
   context 'メールアドレスのユーザーがログインしている場合' do
     it '200とカテゴリ一覧を返すこと' do
-      category.places << place
-      category.save
-
       get "/records/#{record.id}/edit", '', login_headers(user)
       expect(response.status).to eq 200
 

--- a/src/app/settings/categories.jade
+++ b/src/app/settings/categories.jade
@@ -7,9 +7,12 @@
     .row(ng-model='categories.categories' ui-sortable='categories.sortable')
       // カテゴリの一覧
       .col-sm-3(ng-repeat='category in categories.categories' id='{{category.id}}')
+        // カテゴリの表示
         .panel.panel-body.col-sm-11.category-card(ng-show='!category.edit_field' ng-style="{'cursor': cursor_type}" ng-mouseenter="cursor_type = 'move'")
           a.pull-right
-            span.glyphicon.glyphicon-trash#right-icon(ng-click='categories.destroyCategory($index)' ng-show='category.breakdowns_count == 0')
+            span.glyphicon.glyphicon-trash#right-icon(
+              ng-click='categories.destroyCategory($index)'
+              ng-show='category.breakdowns_count == 0 && category.records_count == 0')
           div.category-name(ng-style="{'cursor': 'pointer'}" ng-click='categories.editCategory($index)')
             span.glyphicon.glyphicon-plus-sign.green#left-icon(ng-show='category.barance_of_payments')
             span.glyphicon.glyphicon-minus-sign.red#left-icon(ng-hide='category.barance_of_payments')
@@ -23,6 +26,7 @@
 
             span.glyphicon.glyphicon-map-marker#left-icon
             span {{ category.places_count }}
+        // カテゴリの編集フィールド
         .panel.panel-body.col-sm-11.category-card#category(ng-if="category.edit_field")
           .input-group
             .input-group-btn


### PR DESCRIPTION
- カテゴリの一覧に表示されるゴミ箱アイコンは、内訳の件数と収支の件数がともに0件であった場合のみに表示されるようにしました
- カテゴリの削除で、収支が存在していた場合はエラーを返すようにしました
