### PR TITLE
DEPRECATION WARNINGを解消

### DIFF
--- a/app/models/categorize_place.rb
+++ b/app/models/categorize_place.rb
@@ -1,6 +1,6 @@
 class CategorizePlace < ActiveRecord::Base
   counter_culture :category, column_name: 'places_count'
-  belongs_to :category
+  belongs_to :category, counter_cache: 'places_count'
   belongs_to :place
 
   validates :category_id, uniqueness: { scope: :place_id }


### PR DESCRIPTION
以下のwarningを解消しました。

```
DEPRECATION WARNING: Automatic updating of counter caches on through associations has been deprecated, and will be removed in Rails 5. Instead, please set the appropriate counter_cache options on the has_many and belongs_to for your associations to classifications.
```
