### PR TITLE
ユーザーの通貨設定を返すようにする

### DIFF
--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -7,5 +7,6 @@ class MypagesController < ApplicationController
     fetcher = Record::Fetcher
               .new(user: current_user, params: params, sort_type: 'lately')
     @records = fetcher.all
+    @user = current_user
   end
 end

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -3,6 +3,7 @@ class RecordsController < ApplicationController
 
   def index
     fetcher = Record::Fetcher.new(user: current_user, params: params)
+    @user = current_user
     @records = fetcher.all
     @total_count = fetcher.total_count
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -23,7 +23,7 @@ class UsersController < ApplicationController
     end
   end
 
-  def set_display
+  def setting
     if current_user.update(setting_params)
       head 200
     else
@@ -49,6 +49,7 @@ class UsersController < ApplicationController
   end
 
   def setting_params
-    params.permit(:breakdown_field, :place_field, :tag_field, :memo_field)
+    params.permit(:breakdown_field, :place_field, :tag_field, :memo_field,
+                  :currency)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,6 +7,7 @@ class UsersController < ApplicationController
 
   def settings
     @user = current_user
+    @currencies = Settings.currencies
   end
 
   def update

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ActiveRecord::Base
   has_many :records
   has_many :tags
 
-  enum status: { registered: 2, inactive: 1 }
+  enum status: { inactive: 1, registered: 2 }
 
   validates :nickname,
             length: { maximum: Settings.user.nickname.maximum_length }
@@ -19,6 +19,8 @@ class User < ActiveRecord::Base
             length: { maximum: Settings.user.places.maximum_length,
                       too_long: I18n.t('errors.messages.too_many') },
             unless: :admin
+
+  before_create :set_currency
 
   def active?
     registered? # TODO: 有効期限を確認する
@@ -100,5 +102,10 @@ class User < ActiveRecord::Base
       size: Settings.password_token.length,
       expires_at: Settings.new_email_token.expire_after.seconds.from_now
     )
+  end
+
+  def set_currency
+    self.currency = '¥'
+    # TODO: ロケールによりデフォルトを変更する
   end
 end

--- a/app/views/mypages/show.json.jbuilder
+++ b/app/views/mypages/show.json.jbuilder
@@ -27,3 +27,7 @@ json.records do
     json.memo record.memo
   end
 end
+
+json.user do
+  json.currency @user.currency
+end

--- a/app/views/records/index.json.jbuilder
+++ b/app/views/records/index.json.jbuilder
@@ -16,3 +16,7 @@ json.records do
 end
 
 json.total_count @total_count
+
+json.user do
+  json.currency @user.currency
+end

--- a/app/views/records/new.json.jbuilder
+++ b/app/views/records/new.json.jbuilder
@@ -24,4 +24,5 @@ json.user do
   json.place_field @user.place_field
   json.tag_field @user.tag_field
   json.memo_field @user.memo_field
+  json.currency @user.currency
 end

--- a/app/views/users/settings.json.jbuilder
+++ b/app/views/users/settings.json.jbuilder
@@ -3,3 +3,6 @@ json.breakdown_field @user.breakdown_field
 json.place_field @user.place_field
 json.tag_field @user.tag_field
 json.memo_field @user.memo_field
+json.currency @user.currency
+
+json.currencies @currencies

--- a/app/views/users/show.json.jbuilder
+++ b/app/views/users/show.json.jbuilder
@@ -4,6 +4,7 @@ json.email @user.email
 json.new_email @user.new_email
 json.nickname @user.nickname
 json.user_name @user._name
+json.currency @user.currency
 json.admin @user.admin
 
 if @user.try(:auth)

--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,8 @@
     "ng-tags-input": "~3.0.0",
     "angular-color-picker": "angularjs-color-picker#~1.0.2",
     "angulartics-google-analytics": "~0.1.4",
-    "angulike": "~1.2.0"
+    "angulike": "~1.2.0",
+    "angular-i18n": "^1.5.5"
   },
   "devDependencies": {
     "angular-mocks": "~1.4.2"
@@ -46,6 +47,9 @@
         "assets/fonts/bootstrap/glyphicons-halflings-regular.woff",
         "assets/fonts/bootstrap/glyphicons-halflings-regular.woff2"
       ]
+    },
+    "angular-i18n": {
+      "main": "angular-locale_ja-jp.js"
     }
   },
   "resolutions": {

--- a/config/application.yml
+++ b/config/application.yml
@@ -1,4 +1,7 @@
 defaults: &defaults
+  currencies:
+    yen: ¥
+    dollar: $
   mail_from: <%= ENV['PIG_BOOK_MAIL_FROM'] %>
   access_token:
     length: 32

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,7 +45,7 @@ Rails.application.routes.draw do
   resource :user, only: %i(show update) do
     get :authorize_email
     get :settings
-    patch :set_display
+    patch :setting
   end
   resource :feedback, only: %i(create)
   resource :mypage, only: %i(show), on: :collection

--- a/db/migrate/20160506023450_add_currency_to_users.rb
+++ b/db/migrate/20160506023450_add_currency_to_users.rb
@@ -1,0 +1,5 @@
+class AddCurrencyToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :currency, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160425092850) do
+ActiveRecord::Schema.define(version: 20160506023450) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -213,6 +213,7 @@ ActiveRecord::Schema.define(version: 20160425092850) do
     t.boolean  "memo_field",             default: true
     t.boolean  "tag_field",              default: true
     t.string   "new_email"
+    t.string   "currency"
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,6 +8,7 @@ FactoryGirl.define do
     end
     sequence(:nickname) { |n| "ニックネーム#{n}" }
     last_sign_in_at { 2.days.ago }
+    currency { %w(¥ $).sample }
 
     factory :email_user, class: EmailUser do
       sequence(:email) { |n| "email#{n}@example.com" }

--- a/spec/requests/mypage_spec.rb
+++ b/spec/requests/mypage_spec.rb
@@ -84,7 +84,10 @@ describe 'GET /mypage', autodoc: true do
             place_name: record1.place.try(:name),
             memo: record1.memo
           }
-        ]
+        ],
+        user: {
+          currency: user.currency
+        }
       }
       expect(response.body).to be_json_as(json)
     end

--- a/spec/requests/records_spec.rb
+++ b/spec/requests/records_spec.rb
@@ -51,7 +51,10 @@ describe 'GET /records', autodoc: true do
               tags: []
             }
           ],
-          total_count: 2
+          total_count: 2,
+          user: {
+            currency: user.currency
+          }
         }
         expect(response.body).to be_json_as(json)
       end
@@ -77,7 +80,10 @@ describe 'GET /records', autodoc: true do
               tags: []
             }
           ],
-          total_count: 1
+          total_count: 1,
+          user: {
+            currency: user.currency
+          }
         }
         expect(response.body).to be_json_as(json)
       end
@@ -123,7 +129,10 @@ describe 'GET /records', autodoc: true do
               tags: []
             }
           ],
-          total_count: 3
+          total_count: 3,
+          user: {
+            currency: user.currency
+          }
         }
         expect(response.body).to be_json_as(json)
       end
@@ -213,7 +222,8 @@ describe 'GET /records/new', autodoc: true do
           breakdown_field: true,
           place_field: true,
           tag_field: true,
-          memo_field: true
+          memo_field: true,
+          currency: user.currency
         }
       }
       expect(response.body).to be_json_as(json)

--- a/spec/requests/user_spec.rb
+++ b/spec/requests/user_spec.rb
@@ -101,7 +101,9 @@ describe 'GET /user/settings', autodoc: true do
         breakdown_field: user.breakdown_field,
         place_field: user.place_field,
         tag_field: user.tag_field,
-        memo_field: user.memo_field
+        memo_field: user.memo_field,
+        currency: user.currency,
+        currencies: { yen: '¥', dollar: '$' }
       }
       expect(response.body).to be_json_as(json)
     end

--- a/spec/requests/user_spec.rb
+++ b/spec/requests/user_spec.rb
@@ -24,6 +24,7 @@ describe 'GET /user', autodoc: true do
         new_email: user.new_email,
         nickname: user.nickname,
         user_name: user._name,
+        currency: user.currency,
         admin: user.admin
       }
       expect(response.body).to be_json_as(json)
@@ -44,6 +45,7 @@ describe 'GET /user', autodoc: true do
         new_email: user.new_email,
         nickname: user.nickname,
         user_name: user._name,
+        currency: user.currency,
         admin: user.admin,
         auth: {
           name: user.auth.name,
@@ -68,6 +70,7 @@ describe 'GET /user', autodoc: true do
         new_email: user.new_email,
         nickname: user.nickname,
         user_name: user._name,
+        currency: user.currency,
         admin: user.admin,
         auth: {
           name: user.auth.name,
@@ -255,10 +258,10 @@ describe 'PATCH /user', autodoc: true do
   end
 end
 
-describe 'PATCH /user/set_display', autodoc: true do
+describe 'PATCH /user/setting', autodoc: true do
   context 'ログインしていない場合' do
     it '401が返ってくること' do
-      patch '/user/set_display'
+      patch '/user/setting'
       expect(response.status).to eq 401
     end
   end
@@ -271,7 +274,7 @@ describe 'PATCH /user/set_display', autodoc: true do
 
       it '200が返ってくること' do
         expect(user.breakdown_field).to be_truthy
-        patch '/user/set_display', params, login_headers(user)
+        patch '/user/setting', params, login_headers(user)
         expect(response.status).to eq 200
 
         user.reload
@@ -284,7 +287,7 @@ describe 'PATCH /user/set_display', autodoc: true do
 
       it '200が返ってくること' do
         expect(user.place_field).to be_truthy
-        patch '/user/set_display', params, login_headers(user)
+        patch '/user/setting', params, login_headers(user)
         expect(response.status).to eq 200
 
         user.reload

--- a/src/app/settings/base_settings.jade
+++ b/src/app/settings/base_settings.jade
@@ -5,10 +5,12 @@
 
   .panel-body#with-background
     loading-directive
+
+    // 各項目の表示設定
     blockquote
       span {{ 'SETTINGS.DISPLAY' | translate }}
+    p(translate='MESSAGES.DISPLAY_ITEMS')
     .checkbox
-      p(translate='MESSAGES.DISPLAY_ITEMS')
       label.checkbox-inline
         input(type='checkbox' ng-model='base_settings.breakdown_field' ng-change='base_settings.checkSetting()')
         span {{ 'COLUMNS.BREAKDOWN' | translate }}
@@ -21,3 +23,14 @@
       label.checkbox-inline
         input(type='checkbox' ng-model='base_settings.memo_field' ng-change='base_settings.checkSetting()')
         span {{ 'COLUMNS.MEMO' | translate }}
+    br
+
+    // 通貨単位の設定
+    div(ng-show='base_settings.currencies')
+      blockquote
+        span {{ 'SETTINGS.CURRENCY' | translate }}
+      p(translate='MESSAGES.SET_CURRENCY_UNIT')
+      form.form-horizontal
+        .form-group
+          .col-sm-2
+            select.form-control(ng-model='base_settings.currency_unit' ng-options='unit.id as unit.name for unit in base_settings.currencies')

--- a/src/assets/i18n/locale-en.json
+++ b/src/assets/i18n/locale-en.json
@@ -151,6 +151,7 @@
     "SEND_MAIL": "Send a Mail",
     "SEND_MESSAGE": "Send a Message",
     "SEND_MESSAGE_TO_ADMIN": "Send your message",
+    "SET_CURRENCY_UNIT": "Set your Currency unit. Incidentally, It will affect all of the data",
     "THERE_IS_NO_RECORD": "There is not record.",
     "THERE_IS_NO_RECORD2": " : Input your data :)",
     "UPDATE_PASSWORD": "Your Password has been changed",
@@ -197,6 +198,7 @@
     "PROPER_LAW": "PROPER LAW"
   },
   "SETTINGS": {
+    "CURRENCY": "Currency Unit Setting",
     "DISPLAY": "Display Setting"
   }
 }

--- a/src/assets/i18n/locale-ja.json
+++ b/src/assets/i18n/locale-ja.json
@@ -152,6 +152,7 @@
     "SEND_MAIL": "メールを送信しました",
     "SEND_MESSAGE": "メッセージを送信しました",
     "SEND_MESSAGE_TO_ADMIN": "管理者にメッセージを送信しました",
+    "SET_CURRENCY_UNIT": "通貨の単位を設定してください。すでに登録されているデータは設定した通貨単位に統一されます。",
     "THERE_IS_NO_RECORD": "登録されているデータはありません。",
     "THERE_IS_NO_RECORD2": " からデータを登録してみてください♪",
     "UPDATE_PASSWORD": "パスワードを変更しました",
@@ -199,6 +200,7 @@
     "PROPER_LAW": "準拠法"
   },
   "SETTINGS": {
+    "CURRENCY": "通貨単位の設定",
     "DISPLAY": "各項目の表示設定"
   }
 }


### PR DESCRIPTION
- 以下のページにユーザーの通貨設定を返すようにしました
  - マイページ
  - 入力する
  - リスト
  - プロフィール
- 設定用のメソッド名を変更しました
- ユーザー登録時にデフォルトのcurrencyを登録するようにしました
- usersテーブルに`currency`カラムを追加しました
