### PR TITLE
同じメールアドレスをメール認証しようとした場合メールを送信しない

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -23,6 +23,7 @@ class UsersController < ApplicationController
     end
   end
 
+  # PATCH /user/setting
   def setting
     if current_user.update(setting_params)
       head 200
@@ -39,6 +40,19 @@ class UsersController < ApplicationController
       redirect_to "#{host}/#/?updated_email=ok"
     else
       render_error user, 401
+    end
+  end
+
+  # POST /user/send_mail
+  def send_mail
+    user_updator = User::Updator
+                   .new(user: current_user,
+                        params: { new_email: current_user.new_email })
+    origin = "#{request.protocol}#{request.host_with_port}"
+    if user_updator.send_mail(origin)
+      head 200
+    else
+      render_error user_updator
     end
   end
 

--- a/app/models/user/updator.rb
+++ b/app/models/user/updator.rb
@@ -18,6 +18,7 @@ class User::Updator
   end
 
   def send_mail(origin)
+    return false unless @new_email.present?
     @user.remove_token(:new_email)
     UserMailer.set_new_email(@user.new_email, @user.new_email_url(origin))
               .deliver_now

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,7 @@ Rails.application.routes.draw do
     get :authorize_email
     get :settings
     patch :setting
+    post :send_mail, on: :collection
   end
   resource :feedback, only: %i(create)
   resource :mypage, only: %i(show), on: :collection

--- a/src/app/components/modals/send_mail.jade
+++ b/src/app/components/modals/send_mail.jade
@@ -1,4 +1,8 @@
+.modal-header
+  button.btn.btn-success(type='submit' translate='BUTTONS.YES' ng-click='send_mail.ok()')
+  a.btn.btn-default.pull-right(ng-click='send_mail.cancel()')
+    span.glyphicon.glyphicon-remove#left-icon
+    span {{ 'BUTTONS.CLOSE' | translate }}
+
 .modal-body
   p(translate='MESSAGES.CONFIRM_TO_SEND_MAIL')
-  button.btn.btn-success(type='submit' translate='BUTTONS.YES' ng-click='send_mail.ok()')
-  a.btn.btn-default(ng-click='send_mail.cancel()' translate='BUTTONS.CLOSE')

--- a/src/app/user/modals/confirm_send_mail.controller.coffee
+++ b/src/app/user/modals/confirm_send_mail.controller.coffee
@@ -1,0 +1,15 @@
+ConfirmSendNewMailController = ($modalInstance, UserFactory) ->
+  'ngInject'
+  vm = this
+
+  vm.ok = () ->
+    UserFactory.postNewMail().then ->
+      $modalInstance.close()
+
+  vm.cancel = () ->
+    $modalInstance.dismiss()
+
+  return
+
+angular.module 'newAccountBook'
+  .controller('ConfirmSendNewMailController', ConfirmSendNewMailController)

--- a/src/app/user/profile.controller.coffee
+++ b/src/app/user/profile.controller.coffee
@@ -11,6 +11,9 @@ ProfileController = (IndexFactory, UserFactory, IndexService) ->
   ).catch (res) ->
     IndexService.loading = false
 
+  vm.cancelNewEmail = () ->
+    vm.email_edit_field = false
+
   vm.updateNickname = () ->
     UserFactory.patchProfile({ nickname: vm.new_nickname }).then ->
       vm.current_user.nickname = vm.new_nickname
@@ -18,10 +21,18 @@ ProfileController = (IndexFactory, UserFactory, IndexService) ->
       IndexService.current_user = vm.current_user
 
   vm.updateNewEmail = () ->
-    UserFactory.patchProfile({ new_email: vm.new_email }).then ->
-      vm.current_user.new_email = vm.new_email
+    if vm.new_email == vm.current_user.email
       vm.email_edit_field = false
-      IndexService.current_user = vm.current_user
+    else
+      UserFactory.patchProfile({ new_email: vm.new_email }).then ->
+        vm.current_user.new_email = vm.new_email
+        vm.current_user.email = vm.new_email
+        vm.email_edit_field = false
+        IndexService.current_user = vm.current_user
+
+  # モーダル
+  vm.sendNewEmail = () ->
+    return
 
   return
 

--- a/src/app/user/profile.controller.coffee
+++ b/src/app/user/profile.controller.coffee
@@ -1,4 +1,4 @@
-ProfileController = (IndexFactory, UserFactory, IndexService) ->
+ProfileController = (IndexFactory, UserFactory, IndexService, $modal) ->
   'ngInject'
   vm = this
   vm.nickname_edit_field = false
@@ -32,6 +32,11 @@ ProfileController = (IndexFactory, UserFactory, IndexService) ->
 
   # モーダル
   vm.sendNewEmail = () ->
+    modalInstance = $modal.open(
+      templateUrl: 'app/components/modals/send_mail.html'
+      controller: 'ConfirmSendNewMailController'
+      controllerAs: 'send_mail'
+    )
     return
 
   return

--- a/src/app/user/profile.jade
+++ b/src/app/user/profile.jade
@@ -50,15 +50,19 @@
               span(translate='ERRORS.EMAIL')
           .col-sm-5
             button.btn.btn-success(
-              type='submit'
               ng-click='profile.updateNewEmail()'
               ng-show='profile.email_edit_field')
               span(translate='BUTTONS.AUTH_EMAIL')
+            button.btn.btn-default(
+              ng-click='profile.cancelNewEmail()'
+              ng-show='profile.email_edit_field')
+              span(translate='BUTTONS.CANCEL')
         .form-group(ng-show='profile.current_user.new_email && !profile.email_edit_field')
           .col-sm-2
           .col-sm-5
             label.modal-label#left-icon(for='new_email' translate='LABELS.PRE_AUTH')
             span {{ profile.current_user.new_email }}
+            span.green.glyphicon.glyphicon-envelope#right-icon(ng-click='profile.sendNewEmail()')
         // ニックネーム
         .form-group
           label.col-sm-2.control-label(for='new_nickname' translate='LABELS.NICKNAME')
@@ -82,7 +86,6 @@
               span(translate='ERRORS.MAXLENGTH.NICKNAME')
           .col-sm-5
             button.btn.btn-success(
-              type='submit'
               ng-click='profile.updateNickname()'
               ng-show='profile.nickname_edit_field')
               span(translate='BUTTONS.UPDATE')

--- a/src/app/user/user.factory.coffee
+++ b/src/app/user/user.factory.coffee
@@ -83,6 +83,22 @@ UserFactory = ($location, $q, $http, localStorageService, toastr, $translate, In
           IndexService.loading = false
           return
       return defer.promise
+
+    postNewMail: () ->
+      defer = $q.defer()
+      token = localStorageService.get('access_token')
+      login_headers = {
+        headers: { Authorization: 'Token token=' + token }
+      }
+      $http.post host + 'user/send_mail', '', login_headers
+        .success((data) ->
+          defer.resolve data
+          toastr.success $translate.instant('MESSAGES.SEND_MAIL')
+          return
+        ).error (data) ->
+          defer.reject data
+          return
+      return defer.promise
   }
 
 


### PR DESCRIPTION
- 同じメールアドレスをメール認証しようとしてもメールが送信されないようにしました
- キャンセルボタンを追加し、キャンセルボタンで編集モードを解除するようにしました
- 同じメールアドレスではない場合のみメールが送信されるようになりました
- 認証待ちメールアドレスに再送用のメールアイコンを追加しました
- メールアドレスを変更後、エンターキーで保存できない問題を修正しました
- 認証待ちメールへメールを送信するAPIを追加しました
