### PR TITLE
エンターキーでニックネームが更新できない

### DIFF
--- a/src/app/user/profile.controller.coffee
+++ b/src/app/user/profile.controller.coffee
@@ -22,8 +22,6 @@ ProfileController = (IndexFactory, UserFactory, IndexService, $modal) ->
         IndexService.current_user = vm.current_user
 
   vm.updateNewEmail = () ->
-    console.log 'adf'
-
     if vm.new_email == vm.current_user.email
       vm.email_edit_field = false
     else

--- a/src/app/user/profile.controller.coffee
+++ b/src/app/user/profile.controller.coffee
@@ -14,13 +14,16 @@ ProfileController = (IndexFactory, UserFactory, IndexService, $modal) ->
   vm.cancelNewEmail = () ->
     vm.email_edit_field = false
 
-  vm.updateNickname = () ->
-    UserFactory.patchProfile({ nickname: vm.new_nickname }).then ->
-      vm.current_user.nickname = vm.new_nickname
-      vm.nickname_edit_field = false
-      IndexService.current_user = vm.current_user
+  vm.updateNickname = (e = undefined) ->
+    if e == undefined or e.which == 13
+      UserFactory.patchProfile({ nickname: vm.new_nickname }).then ->
+        vm.current_user.nickname = vm.new_nickname
+        vm.nickname_edit_field = false
+        IndexService.current_user = vm.current_user
 
   vm.updateNewEmail = () ->
+    console.log 'adf'
+
     if vm.new_email == vm.current_user.email
       vm.email_edit_field = false
     else

--- a/src/app/user/profile.jade
+++ b/src/app/user/profile.jade
@@ -13,7 +13,7 @@
         footer(translate='LABELS.EMAIL_LOGIN' ng-show="profile.current_user.type == 'EmailUser'")
         footer(translate='LABELS.TWITTER_LOGIN' ng-show="profile.current_user.type == 'TwitterUser'")
         footer(translate='LABELS.FACEBOOK_LOGIN' ng-show="profile.current_user.type == 'FacebookUser'")
-      form.form.form-horizontal(novalidate=true name='profileForm')
+      .form.form-horizontal(novalidate=true name='profileForm')
         // ユーザー名
         .form-group(ng-show="profile.current_user.type == 'TwitterUser'")
           label.col-sm-2.control-label(for='auth.name' translate='COLUMNS.USER_NAME')
@@ -80,6 +80,7 @@
               ng-value='profile.current_user.nickname'
               ng-init='profile.new_nickname = profile.current_user.nickname'
               ng-model='profile.new_nickname'
+              ng-keydown='profile.updateNickname($event)'
               ng-maxlength='100')
             span.errors(ng-show='profileForm.new_nickname.$error.maxlength')
               span.glyphicon.glyphicon-alert


### PR DESCRIPTION
原因は、formタグ内にbuttonタグが複数あったために最初のメールアドレス認証のボタンに反応していました。
ng-keydownを使い、エンターキーが入力された場合のイベントを登録するようにしました。
