### PR TITLE
カテゴリ追加時に、収支選択のみでエラーメッセージが表示される

### DIFF
--- a/src/app/settings/categories.jade
+++ b/src/app/settings/categories.jade
@@ -57,7 +57,7 @@
         .panel.panel-body.col-sm-11.category-card#category(ng-if='categories.add_field')
           form.form-inline(novalidate=true name='newCategoryForm' ng-submit='categories.createCategory()')
             // エラーメッセージ
-            span.errors(ng-messages='newCategoryForm.name.$error' ng-show='newCategoryForm.$dirty || newCategoryForm.$submitted')
+            span.errors(ng-messages='newCategoryForm.name.$error' ng-show='newCategoryForm.name.$dirty || newCategoryForm.$submitted')
               div(ng-message='required')
                 span.glyphicon.glyphicon-alert#left-icon
                 span(translate='ERRORS.REQUIRED.CATEGORY_NAME')


### PR DESCRIPTION
- エラーメッセージが表示されるのは、ボタンクリック時、またはテキストフィールドがすでに編集された際に、エラーが発生している場合のみにしました。
