### PR TITLE
作成数の制限をサーバーとフロントで連携する

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -2,7 +2,8 @@ class CategoriesController < ApplicationController
   before_action :authenticate
 
   def index
-    @categories = current_user.categories.order(:position)
+    @user = current_user
+    @categories = @user.categories.order(:position)
   end
 
   def create

--- a/app/controllers/category/breakdowns_controller.rb
+++ b/app/controllers/category/breakdowns_controller.rb
@@ -3,6 +3,7 @@ class Category::BreakdownsController < ApplicationController
   before_action :set_category
 
   def index
+    @user = current_user
     @breakdowns = @category.breakdowns.order(:id)
   end
 

--- a/app/controllers/places_controller.rb
+++ b/app/controllers/places_controller.rb
@@ -3,7 +3,8 @@ class PlacesController < ApplicationController
   before_action :set_place, only: [:update, :destroy]
 
   def index
-    @places = current_user.places.includes(:categories).order(created_at: :desc)
+    @user = current_user
+    @places = @user.places.includes(:categories).order(created_at: :desc)
   end
 
   def create

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -1,0 +1,10 @@
+class AdminUser < User
+  def maximum_values
+    {
+      category: Settings.user.categories.admin_maximum_length,
+      breakdown: Settings.category.breakdowns.admin_maximum_length,
+      place: Settings.user.places.admin_maximum_length,
+      record: Settings.user.records.admin_maximum_length
+    }
+  end
+end

--- a/app/models/email_user.rb
+++ b/app/models/email_user.rb
@@ -8,6 +8,10 @@ class EmailUser < User
             on: :create
   validate :uniqueness_email, if: 'email.present?'
 
+  def _name
+    nickname || email
+  end
+
   def registration_url(origin)
     token = registration_token.token
     "#{origin}/email_user/registrations/#{id}/regist?token=#{token}"

--- a/app/models/facebook_user.rb
+++ b/app/models/facebook_user.rb
@@ -13,4 +13,8 @@ class FacebookUser < User
     fb_user.auth = auth_data
     fb_user
   end
+
+  def _name
+    nickname || auth.try(:name) || auth.try(:screen_name)
+  end
 end

--- a/app/models/twitter_user.rb
+++ b/app/models/twitter_user.rb
@@ -12,4 +12,8 @@ class TwitterUser < User
     twitter_user.auth = auth_data
     twitter_user
   end
+
+  def _name
+    nickname || auth.try(:name) || auth.try(:screen_name)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -98,8 +98,6 @@ class User < ActiveRecord::Base
     end
   end
 
-  private
-
   def maximum_values
     {
       category: Settings.user.categories.maximum_length,
@@ -108,6 +106,8 @@ class User < ActiveRecord::Base
       record: Settings.user.records.maximum_length
     }
   end
+
+  private
 
   def add_new_email_token
     add_token(

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -98,7 +98,7 @@ class User < ActiveRecord::Base
 
   def each_maximum_values
     if admin?
-      user = self.becomes(AdminUser)
+      user = becomes(AdminUser)
       user.maximum_values
     else
       maximum_values

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,7 @@ class User < ActiveRecord::Base
 
   validates :nickname,
             length: { maximum: Settings.user.nickname.maximum_length }
+  # TODO: ユーザーのランクによって制限数を変更する
   validates :categories,
             length: { maximum: Settings.user.categories.maximum_length,
                       too_long: I18n.t('errors.messages.too_many') },
@@ -95,7 +96,25 @@ class User < ActiveRecord::Base
     end
   end
 
+  def get_maximum_values
+    if admin?
+      user = self.becomes(AdminUser)
+      user.maximum_values
+    else
+      maximum_values
+    end
+  end
+
   private
+
+  def maximum_values
+    {
+      category: Settings.user.categories.maximum_length,
+      breakdown: Settings.category.breakdowns.maximum_length,
+      place: Settings.user.places.maximum_length,
+      record: Settings.user.records.maximum_length
+    }
+  end
 
   def add_new_email_token
     add_token(

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,6 +43,7 @@ class User < ActiveRecord::Base
     end
   end
 
+  # TODO: label_nameとして各classに移動させる
   def type_label_name
     case type
     when 'EmailUser' then 'label-warning'
@@ -61,14 +62,6 @@ class User < ActiveRecord::Base
 
   def last_login_time
     I18n.l(last_sign_in_at) if last_sign_in_at
-  end
-
-  def _name
-    if type == 'EmailUser'
-      nickname || email
-    else
-      nickname || auth.try(:name) || auth.try(:screen_name)
-    end
   end
 
   def self.find_or_create(auth)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -96,7 +96,7 @@ class User < ActiveRecord::Base
     end
   end
 
-  def get_maximum_values
+  def each_maximum_values
     if admin?
       user = self.becomes(AdminUser)
       user.maximum_values

--- a/app/views/categories/index.json.jbuilder
+++ b/app/views/categories/index.json.jbuilder
@@ -8,3 +8,5 @@ json.categories do
     json.records_count category.records_count
   end
 end
+
+json.max_category_count @user.each_maximum_values[:category]

--- a/app/views/category/breakdowns/index.json.jbuilder
+++ b/app/views/category/breakdowns/index.json.jbuilder
@@ -9,3 +9,5 @@ json.breakdowns do
     json.name breakdown.name
   end
 end
+
+json.max_breakdown_count @user.each_maximum_values[:breakdown]

--- a/app/views/places/index.json.jbuilder
+++ b/app/views/places/index.json.jbuilder
@@ -11,3 +11,5 @@ json.places do
     end
   end
 end
+
+json.max_place_count @user.each_maximum_values[:place]

--- a/app/views/users/show.json.jbuilder
+++ b/app/views/users/show.json.jbuilder
@@ -13,3 +13,4 @@ if @user.try(:auth)
     json.screen_name @user.auth.try(:screen_name)
   end
 end
+

--- a/app/views/users/show.json.jbuilder
+++ b/app/views/users/show.json.jbuilder
@@ -14,3 +14,4 @@ if @user.try(:auth)
   end
 end
 
+json.max_values @user.each_maximum_values

--- a/config/application.yml
+++ b/config/application.yml
@@ -77,13 +77,19 @@ test:
   <<: *defaults
   category:
     breakdowns:
+      admin_maximum_length: 5
       maximum_length: 3
     name:
       maximum_length: 100
   user:
     categories:
+      admin_maximum_length: 5
       maximum_length: 3
     places:
+      admin_maximum_length: 5
+      maximum_length: 3
+    records:
+      admin_maximum_length: 5
       maximum_length: 3
     nickname:
       maximum_length: 100

--- a/config/application.yml
+++ b/config/application.yml
@@ -20,6 +20,7 @@ defaults: &defaults
   category:
     breakdowns:
       maximum_length: 20
+      admin_maximum_length: 99
     name:
       maximum_length: 100
   place:
@@ -31,8 +32,13 @@ defaults: &defaults
   user:
     categories:
       maximum_length: 20
+      admin_maximum_length: 99
     places:
-      maximum_length: 100
+      maximum_length: 20
+      admin_maximum_length: 99
+    records:
+      maximum_length: 200
+      admin_maximum_length: 999
     nickname:
       maximum_length: 100
     email:

--- a/spec/factories/feedbacks.rb
+++ b/spec/factories/feedbacks.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :feedback do
     trait :login_user do
-      user
+      association :user, factory: :email_user
       email nil
     end
     email { Faker::Internet.email }

--- a/spec/requests/categories_spec.rb
+++ b/spec/requests/categories_spec.rb
@@ -39,7 +39,8 @@ describe 'GET /categories', autodoc: true do
             places_count: 0,
             records_count: 0
           }
-        ]
+        ],
+        max_category_count: Settings.user.categories.maximum_length
       }
       expect(response.body).to be_json_as(json)
     end

--- a/spec/requests/category/breakdowns_spec.rb
+++ b/spec/requests/category/breakdowns_spec.rb
@@ -28,7 +28,8 @@ describe 'GET /categories/:category_id/breakdowns', autodoc: true do
             id: breakdown.id,
             name: breakdown.name
           }
-        ]
+        ],
+        max_breakdown_count: Settings.category.breakdowns.maximum_length
       }
       expect(response.body).to be_json_as(json)
     end

--- a/spec/requests/feedback_spec.rb
+++ b/spec/requests/feedback_spec.rb
@@ -5,7 +5,7 @@ describe 'POST /feedback?user_id=user_id&email=email&content=content',
   let!(:content) { '問い合わせ内容' }
 
   context 'ログインしている場合' do
-    let!(:user) { create(:user, :registered) }
+    let!(:user) { create(:email_user, :registered) }
     let!(:params) { { user_id: user.id, content: content } }
 
     context '各値が正しい場合' do

--- a/spec/requests/places_spec.rb
+++ b/spec/requests/places_spec.rb
@@ -37,7 +37,8 @@ describe 'GET /places', autodoc: true do
               barance_of_payments: category.barance_of_payments
             ]
           }
-        ]
+        ],
+        max_place_count: Settings.user.places.maximum_length
       }
       expect(response.body).to be_json_as(json)
     end

--- a/spec/requests/user_spec.rb
+++ b/spec/requests/user_spec.rb
@@ -10,6 +10,28 @@ describe 'GET /user', autodoc: true do
     end
   end
 
+  context '管理者ユーザーがログインしている場合' do
+    let!(:user) { create(:email_user, :registered, :admin_user, email: email) }
+
+    it '200とユーザー情報を返すこと' do
+      get '/user', '', login_headers(user)
+      expect(response.status).to eq 200
+
+      json = {
+        id: user.id,
+        type: user.type,
+        email: user.email,
+        new_email: user.new_email,
+        nickname: user.nickname,
+        user_name: user._name,
+        currency: user.currency,
+        admin: user.admin,
+        max_values: user.each_maximum_values
+      }
+      expect(response.body).to be_json_as(json)
+    end
+  end
+
   context 'メールアドレスのユーザーがログインしている場合' do
     let!(:user) { create(:email_user, :registered, email: email) }
 
@@ -25,7 +47,8 @@ describe 'GET /user', autodoc: true do
         nickname: user.nickname,
         user_name: user._name,
         currency: user.currency,
-        admin: user.admin
+        admin: user.admin,
+        max_values: user.each_maximum_values
       }
       expect(response.body).to be_json_as(json)
     end
@@ -50,7 +73,8 @@ describe 'GET /user', autodoc: true do
         auth: {
           name: user.auth.name,
           screen_name: user.auth.screen_name
-        }
+        },
+        max_values: user.each_maximum_values
       }
       expect(response.body).to be_json_as(json)
     end
@@ -75,7 +99,8 @@ describe 'GET /user', autodoc: true do
         auth: {
           name: user.auth.name,
           screen_name: user.auth.screen_name
-        }
+        },
+        max_values: user.each_maximum_values
       }
       expect(response.body).to be_json_as(json)
     end

--- a/src/app/settings/categories.controller.coffee
+++ b/src/app/settings/categories.controller.coffee
@@ -7,6 +7,7 @@ CategoriesController = (SettingsFactory, $modal, IndexService) ->
   IndexService.loading = true
   SettingsFactory.getCategories().then((res) ->
     vm.categories = res.categories
+    vm.max_category_count = res.max_category_count
     IndexService.loading = false
   ).catch (res) ->
     IndexService.loading = false

--- a/src/app/settings/categories.jade
+++ b/src/app/settings/categories.jade
@@ -51,7 +51,7 @@
             button.btn.btn-success(translate='BUTTONS.EDIT' ng-disabled='editCategoryForm.$dirty && editCategoryForm.$invalid')
             a.btn.btn-default.pull-right(translate='BUTTONS.CANCEL' ng-click='category.edit_field = false')
       // カテゴリの追加フィールド
-      .col-sm-3(ng-show='categories.categories && categories.categories.length < 20')
+      .col-sm-3(ng-show='categories.categories && categories.categories.length < categories.max_category_count')
         .panel.panel-body.col-sm-11.category-plus#category(ng-click='categories.addNewPanel()' ng-class="{'panel-background': 'adding'}" ng-mouseenter="adding = true" ng-mouseleave="adding = false" ng-show="!categories.add_field")
           span.glyphicon.glyphicon-plus
         .panel.panel-body.col-sm-11.category-card#category(ng-if='categories.add_field')

--- a/src/app/settings/modals/breakdowns.controller.coffee
+++ b/src/app/settings/modals/breakdowns.controller.coffee
@@ -4,6 +4,7 @@ BreakdownsController = (SettingsFactory, category_id, $modalInstance, $modal) ->
 
   SettingsFactory.getBreakdowns(category_id).then (res) ->
     vm.breakdowns = res.breakdowns
+    vm.max_breakdown_count = res.max_breakdown_count
 
   vm.createBreakdown = (e) ->
     if e == undefined || e.which == 13

--- a/src/app/settings/modals/breakdowns.jade
+++ b/src/app/settings/modals/breakdowns.jade
@@ -1,5 +1,6 @@
 .modal-body
   loading-directive(target='modal')
+  // 編集フィールド
   div(id='breakdown.id' ng-repeat='breakdown in breakdowns.breakdowns')
     p(ng-click='breakdown.edit_field = true' ng-show='!breakdown.edit_field') {{ breakdown.name }}
     .form.form-inline(ng-if='breakdown.edit_field')
@@ -7,7 +8,17 @@
       button.btn.btn-success(translate='BUTTONS.EDIT' ng-click='breakdowns.updateBreakdown($index)')
       button.btn.btn-default(translate='BUTTONS.CANCEL' ng-click='breakdown.edit_field = false')
       button.btn.btn-info.pull-right(href='' translate='LINKS.DELETE' ng-click='breakdowns.destroyBreakdown($index)')
-  a(href='' ng-click='breakdowns.new_breakdown_field = true' translate='BUTTONS.ADD' ng-show='!breakdowns.new_breakdown_field && breakdowns.breakdowns')
+  // 追加フィールド
   form(novalidate=true name='newBreakdownForm' ng-submit='breakdowns.submit()')
+    a(href='' ng-click='breakdowns.new_breakdown_field = true'
+      translate='BUTTONS.ADD'
+      ng-if='!breakdowns.new_breakdown_field && breakdowns.breakdowns && breakdowns.breakdowns.length < breakdowns.max_breakdown_count')
     .form-group(ng-if='breakdowns.new_breakdown_field')
-      input.form-control(type='text' autofocus=true name='breakdowns.new-breakdown' ng-model='breakdowns.new_breakdown' required=true ng-maxlength='100' ng-keydown='breakdowns.createBreakdown($event)')
+      input.form-control(
+        type='text'
+        autofocus=true
+        name='breakdowns.new-breakdown'
+        ng-model='breakdowns.new_breakdown'
+        required=true
+        ng-maxlength='100'
+        ng-keydown='breakdowns.createBreakdown($event)')

--- a/src/app/settings/places.controller.coffee
+++ b/src/app/settings/places.controller.coffee
@@ -6,6 +6,7 @@ PlacesController = (SettingsFactory, $scope, IndexService, $modal, toastr, $tran
   IndexService.loading = true
   SettingsFactory.getPlaces().then((res) ->
     vm.places = res.places
+    vm.max_place_count = res.max_place_count
     IndexService.loading = false
   ).catch (res) ->
     IndexService.loading = false

--- a/src/app/settings/places.jade
+++ b/src/app/settings/places.jade
@@ -5,7 +5,12 @@
 
   .panel-body#with-background
     //- 追加パネル
-    .panel.panel-body.place-plus(ng-click='places.newPlace()' ng-class="{'panel-background': 'adding'}" ng-mouseenter="adding = true" ng-mouseleave="adding = false" ng-show="!places.add_field")
+    .panel.panel-body.place-plus(
+      ng-click='places.newPlace()'
+      ng-class="{'panel-background': 'adding'}"
+      ng-mouseenter="adding = true"
+      ng-mouseleave="adding = false"
+      ng-show="!places.add_field && places.places.length < places.max_place_count")
       span.glyphicon.glyphicon-plus
 
     .panel.panel-body.place-card(ng-if='places.add_field')


### PR DESCRIPTION
- ユーザーの各コンテンツの作成制限数をサーバーから返すようにしました
- user.rbがfatモデルになっているので、`_name`を各typeごとのclassに移動しました
- 管理者の場合は、作成数が一般ユーザーと異なるテストを追加しました
- 以下の部分について、作成制限数に合わせて表示、非表示をするようにしました
  - カテゴリ画面の「追加」フィールド
  - カテゴリ画面の内訳一覧モーダルの「追加」フィールド
  - お店・施設画面の「追加」フィールド
