### PR TITLE
「入力する」画面のリストの日付が動的に変更されるように修正

### DIFF
--- a/src/app/records/new_record.controller.coffee
+++ b/src/app/records/new_record.controller.coffee
@@ -29,6 +29,7 @@ NewRecordController = (IndexService, toastr, RecordsFactory, $scope, $modal, Set
     params =
       date: String(target_date)
     RecordsFactory.getRecords(params).then((res) ->
+      vm.records_published_at = target_date
       vm.day_records = res.records
       IndexService.records_loading = false
     ).catch (res) ->


### PR DESCRIPTION
「入力する」画面のリストは、入力フォームの日付が変更されても変更されないため、変更されるようにしました
