### PR TITLE
収支の修正で金額が負の場合、エラーが表示されず金額以外が更新できる問題を修正

### DIFF
--- a/spec/requests/records_spec.rb
+++ b/spec/requests/records_spec.rb
@@ -402,6 +402,20 @@ describe 'PATCH /records/:id', autodoc: true do
       expect(response.body).to be_json_as(json)
     end
   end
+
+  context '金額が負の値の場合' do
+    let(:charge) { '-20' }
+
+    it '422とエラーメッセージが返ってくること' do
+      patch "/records/#{record.id}", params, login_headers(user)
+
+      expect(response.status).to eq 422
+      json = {
+        error_messages: ['金額は0以上の値にしてください']
+      }
+      expect(response.body).to be_json_as(json)
+    end
+  end
 end
 
 describe 'DELETE /records/:id', autodoc: true do

--- a/src/app/records/modals/edit_record.controller.coffee
+++ b/src/app/records/modals/edit_record.controller.coffee
@@ -56,8 +56,10 @@ EditRecordController = (IndexService, RecordsFactory, record_id, $modalInstance,
       charge: vm.charge
       memo: vm.memo
       tags: vm.tags
-    RecordsFactory.patchRecord(record_id, params).then (res) ->
+    RecordsFactory.patchRecord(record_id, params).then((res) ->
       $modalInstance.close()
+    ).catch (res) ->
+      vm.errors = res.error_messages
 
   vm.selectCategory = () ->
     vm.categories.forEach (item, i) ->

--- a/src/app/records/modals/record.jade
+++ b/src/app/records/modals/record.jade
@@ -6,7 +6,7 @@ form.form-horizontal(novalidate=true name='editRecordForm' ng-submit='edit_recor
       span {{ 'BUTTONS.EDIT' | translate }}
     button.btn.btn-success(translate='BUTTONS.UPDATE'
                            ng-click='edit_record.updateRecord()'
-                           ng-disabled='editRecordForm.$submitted && editRecordForm.$invalid'
+                           ng-disabled='editRecordForm.$invalid'
                            ng-show='edit_record.editing')
     a.btn.btn-default.pull-right(ng-click='edit_record.cancel()')
       span.glyphicon.glyphicon-remove#left-icon
@@ -107,17 +107,17 @@ form.form-horizontal(novalidate=true name='editRecordForm' ng-submit='edit_recor
       .col-sm-10(ng-show='edit_record.editing')
         .input-group
           span.input-group-addon {{ edit_record.user.currency }}
-          input.form-control(type='number' name='charge' ng-model='edit_record.charge' required='true' max=9999999 min=0)
-          span.errors(ng-messages='newRecordForm.charge.$error' ng-show='newRecordForm.$submitted && newRecordForm.charge.$error')
-            div(ng-message='required')
-              span.glyphicon.glyphicon-alert#left-icon
-              span(translate='ERRORS.REQUIRED.CHARGE')
-            div(ng-message='max')
-              span.glyphicon.glyphicon-alert#left-icon
-              span(translate='ERRORS.MAX.CHARGE')
-            div(ng-message='min')
-              span.glyphicon.glyphicon-alert#left-icon
-              span(translate='ERRORS.MIN.CHARGE')
+          input.form-control(type='number' name='charge' ng-model='edit_record.charge' required=true max=9999999 min=0)
+        span.errors(ng-messages='editRecordForm.charge.$error' ng-show='editRecordForm.$submitted && editRecordForm.charge.$error')
+          div(ng-message='required')
+            span.glyphicon.glyphicon-alert#left-icon
+            span(translate='ERRORS.REQUIRED.CHARGE')
+          div(ng-message='max')
+            span.glyphicon.glyphicon-alert#left-icon
+            span(translate='ERRORS.MAX.CHARGE')
+          div(ng-message='min')
+            span.glyphicon.glyphicon-alert#left-icon
+            span(translate='ERRORS.MIN.CHARGE')
     // 備考
     .form-group(ng-show='edit_record.form_group_memo')
       label.control-label.col-sm-2(for='memo')
@@ -126,7 +126,7 @@ form.form-horizontal(novalidate=true name='editRecordForm' ng-submit='edit_recor
         span {{ edit_record.record.memo }}
       .col-sm-10(ng-show='edit_record.editing')
         textarea.form-control(name='memo' ng-model='edit_record.memo' ng-maxlength='10000')
-        span.errors(ng-messages='newRecordForm.memo.$error' ng-show='newRecordForm.$submitted && newRecordForm.memo.$error')
+        span.errors(ng-messages='editRecordForm.memo.$error' ng-show='editRecordForm.$submitted && editRecordForm.memo.$error')
           div(ng-message='maxlength')
             span.glyphicon.glyphicon-alert#left-icon
             span(translate='ERRORS.MAXLENGTH.MEMO')

--- a/src/app/records/new.jade
+++ b/src/app/records/new.jade
@@ -120,16 +120,16 @@
             .input-group
               span.input-group-addon {{ new_record.user.currency }}
               input.form-control(type='number' name='charge' ng-model='new_record.charge' required='true' max=9999999 min=0)
-              span.errors(ng-messages='newRecordForm.charge.$error' ng-show='newRecordForm.$submitted && newRecordForm.charge.$error')
-                div(ng-message='required')
-                  span.glyphicon.glyphicon-alert#left-icon
-                  span(translate='ERRORS.REQUIRED.CHARGE')
-                div(ng-message='max')
-                  span.glyphicon.glyphicon-alert#left-icon
-                  span(translate='ERRORS.MAX.CHARGE')
-                div(ng-message='min')
-                  span.glyphicon.glyphicon-alert#left-icon
-                  span(translate='ERRORS.MIN.CHARGE')
+            span.errors(ng-messages='newRecordForm.charge.$error' ng-show='newRecordForm.$submitted && newRecordForm.charge.$error')
+              div(ng-message='required')
+                span.glyphicon.glyphicon-alert#left-icon
+                span(translate='ERRORS.REQUIRED.CHARGE')
+              div(ng-message='max')
+                span.glyphicon.glyphicon-alert#left-icon
+                span(translate='ERRORS.MAX.CHARGE')
+              div(ng-message='min')
+                span.glyphicon.glyphicon-alert#left-icon
+                span(translate='ERRORS.MIN.CHARGE')
         // 備考
         .form-group(ng-show='new_record.form_group_memo')
           label.control-label.col-sm-2(for='memo')


### PR DESCRIPTION
- 金額でエラーが発生した場合、エラーメッセージの表示部分のレイアウトが崩れる問題を修正しました
- 収支の修正モーダルで、金額が負の場合、エラーが表示されずに正常にモーダルが閉じてしまう問題を修正しました。
