### PR TITLE
入力によるエラーは404ではなく422を返すようにする

### DIFF
--- a/app/controllers/email_user/registrations_controller.rb
+++ b/app/controllers/email_user/registrations_controller.rb
@@ -25,7 +25,6 @@ class EmailUser::RegistrationsController < ApplicationController
 
   def recreate
     @user = EmailUser.inactive.find_by(email: params[:email])
-    raise ActiveRecord::RecordNotFound if params[:email].present? && @user.nil?
     @registration = EmailUser::RegistrationToken.new(@user, params[:email])
     origin = "#{request.protocol}#{request.host_with_port}"
     if @registration.recreate(origin)

--- a/app/models/email_user/registration_token.rb
+++ b/app/models/email_user/registration_token.rb
@@ -1,12 +1,13 @@
 class EmailUser::RegistrationToken
   include ActiveModel::Model
 
-  attr_accessor :email
+  attr_accessor :user, :email
   validates :email, presence: true
+  validate :should_find_user, if: 'email.present? && user.nil?'
 
-  def initialize(user, email)
+  def initialize(user, email = nil)
     @user = user
-    self.email = email
+    @email = email
   end
 
   def recreate(origin)
@@ -14,5 +15,11 @@ class EmailUser::RegistrationToken
     @user.remove_token(:registration)
     UserMailer.registration(@user.email, @user.registration_url(origin))
               .deliver_now
+  end
+
+  private
+
+  def should_find_user
+    errors[:base] << I18n.t('errors.messages.registrations.not_found_email')
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -10,6 +10,8 @@ ja:
         destroy_breakdowns: 登録した内訳を削除してから削除してください
         destroy_records: 登録した収支を削除してから削除してください
       too_many: の作成上限は%{count}件です
+      registrations:
+        not_found_email: メールアドレスがすでに本登録されているか、登録されていないメールアドレスです
   labels:
     administrator: 管理者
     status:

--- a/spec/requests/sign_up_spec.rb
+++ b/spec/requests/sign_up_spec.rb
@@ -145,6 +145,7 @@ describe 'PATCH /email_user/registrations/:id?token=token', autodoc: true do
   end
 end
 
+# メールの再送信
 describe 'POST /email_user/registrations/recreate?email=email', autodoc: true do
   let!(:email) { 'login@example.com' }
   let!(:user) { create(:email_user, :inactive, email: 'login@example.com') }
@@ -166,16 +167,26 @@ describe 'POST /email_user/registrations/recreate?email=email', autodoc: true do
       user.save
     end
 
-    it '404が返ってくること' do
+    it '422が返ってくること' do
       patch '/email_user/registrations/recreate', email: email
-      expect(response.status).to eq 404
+      expect(response.status).to eq 422
+
+      json = {
+        error_messages: ['メールアドレスがすでに本登録されているか、登録されていないメールアドレスです']
+      }
+      expect(response.body).to be_json_as(json)
     end
   end
 
   context 'メールアドレスが登録されていない場合' do
-    it '404が返ってくること' do
+    it '422が返ってくること' do
       patch '/email_user/registrations/recreate', email: "dummy#{email}"
-      expect(response.status).to eq 404
+      expect(response.status).to eq 422
+
+      json = {
+        error_messages: ['メールアドレスがすでに本登録されているか、登録されていないメールアドレスです']
+      }
+      expect(response.body).to be_json_as(json)
     end
   end
 

--- a/src/app/account/edit_password.controller.coffee
+++ b/src/app/account/edit_password.controller.coffee
@@ -6,16 +6,12 @@ EditPasswordController = (AccountFactory, $location, $translate) ->
   vm.email = $location.search()['email']
   vm.token = $location.search()['token']
 
-  vm.clearErrors = () ->
-    vm.errors = ''
-
   vm.submit = () ->
     params = {
       password: vm.password
       password_confirmation: vm.password_confirmation
       token: vm.token
     }
-
     AccountFactory.patchNewPassword(vm.user_id, params).catch (res) ->
       if res.error_messages == 'Not Found'
         vm.errors = [$translate.instant('MESSAGES.NOT_FOUND_EMAIL')]

--- a/src/app/account/edit_password.jade
+++ b/src/app/account/edit_password.jade
@@ -4,13 +4,10 @@
 .col-md-9
   .panel.panel-default
     .panel-heading
-      span.glyphicon.glyphicon-leaf
+      span.glyphicon.glyphicon-leaf#left-icon
       span(translate='TITLES.EDIT_PASSWORD')
     .panel-body#with-background
-      .alert.alert-danger(role='alert' ng-show='edit_password.errors')
-        button.close(data-dismiss='alert' type='button' ng-click='edit_password.clearErrors()') ×
-        ul(ng-repeat='error in edit_password.errors')
-          li {{error}}
+      error-messages-directive(errors='edit_password.errors')
       form(novalidate=true name='editPasswordForm' ng-submit='edit_password.submit()')
         .form-group
           label(for='email')
@@ -46,9 +43,10 @@
             div(ng-message='minlength')
               span.glyphicon.glyphicon-alert#left-icon
               span(translate='ERRORS.MINLENGTH.PASSWORD')
- 
-        button.btn.btn-success(type='submit' ng-disabled='editPasswordForm.$submitted && editPasswordForm.$invalid')
-          span {{editPasswordForm.current_password.$error}}
+
+        // ボタン
+        button.btn.btn-success(type='submit' ng-disabled='editPasswordForm.$invalid')
+          span {{ editPasswordForm.current_password.$error }}
           span(translate='BUTTONS.UPDATE')
       hr
       p

--- a/src/app/account/resend_email.controller.coffee
+++ b/src/app/account/resend_email.controller.coffee
@@ -2,9 +2,6 @@ ResendEmailController = (AccountFactory, $translate) ->
   'ngInject'
   vm = this
 
-  vm.clearErrors = () ->
-    vm.errors = ''
-
   vm.submit = () ->
     vm.sending = true
     params = {
@@ -13,10 +10,7 @@ ResendEmailController = (AccountFactory, $translate) ->
     AccountFactory.patchResendEmail(params).then((res) ->
       vm.sending = false
     ).catch (res) ->
-      if res.error_messages[0] == 'Not Found'
-        vm.errors = [$translate.instant('MESSAGES.NOT_FOUND_EMAIL')]
-      else
-        vm.errors = res.error_messages
+      vm.errors = res.error_messages
       vm.sending = false
 
   return

--- a/src/app/account/resend_email.jade
+++ b/src/app/account/resend_email.jade
@@ -7,10 +7,7 @@
       span.glyphicon.glyphicon-heart#left-icon
       span(translate='TITLES.RESEND_EMAIL')
     .panel-body#with-background
-      .alert.alert-danger(role='alert' ng-show='resend_email.errors')
-        button.close(data-dismiss='alert' type='button' ng-click='resend_email.clearErrors()') ×
-        ul(ng-repeat='error in resend_email.errors')
-          li {{error}}
+      error-messages-directive(errors='resend_email.errors')
       p(translate='MESSAGES.RESEND_EMAIL')
       form(novalidate=true name='resendEmailForm' ng-submit='resend_email.submit()')
         .form-group
@@ -28,7 +25,7 @@
             div(ng-message='maxlength')
               span.glyphicon.glyphicon-alert#left-icon
               span(translate='ERRORS.MAXLENGTH.EMAIL')
-        button.btn.btn-success(type='submit' ng-disabled='resendEmailForm.$submitted && resendEmailForm.$invalid || resend_email.sending')
+        button.btn.btn-success(type='submit' ng-disabled='resendEmailForm.$invalid || resend_email.sending')
           span(translate='BUTTONS.SEND')
       hr
       p

--- a/src/app/components/errors/error_messages.controller.coffee
+++ b/src/app/components/errors/error_messages.controller.coffee
@@ -1,0 +1,11 @@
+ErrorMessagesController = ($scope) ->
+  'ngInject'
+  vm = this
+
+  vm.clearErrors = () ->
+    vm.errors = ''
+
+  return
+
+angular.module 'newAccountBook'
+  .controller('ErrorMessagesController', ErrorMessagesController)

--- a/src/app/components/errors/error_messages.directive.coffee
+++ b/src/app/components/errors/error_messages.directive.coffee
@@ -1,0 +1,12 @@
+errorMessagesDirective = () ->
+  directive =
+    restrict: 'E'
+    scope:
+      errors: '='
+    templateUrl: 'app/components/errors/error_messages.html'
+    controller: 'ErrorMessagesController'
+    controllerAs: 'msg'
+    bindToController: true
+
+angular.module 'newAccountBook'
+  .directive('errorMessagesDirective', errorMessagesDirective)

--- a/src/app/components/errors/error_messages.jade
+++ b/src/app/components/errors/error_messages.jade
@@ -1,0 +1,4 @@
+.alert.alert-danger(role='alert' ng-show='msg.errors')
+  button.close(data-dismiss='alert' type='button' ng-click='msg.clearErrors()') ×
+  ul(ng-repeat='error in msg.errors')
+    li {{error}}

--- a/src/assets/i18n/locale-en.json
+++ b/src/assets/i18n/locale-en.json
@@ -8,6 +8,7 @@
     "CATEGORY": "Category",
     "DASHBOARD": "Dashboard",
     "DAY": "Day",
+    "EDIT_PASSWORD": "Edit Password",
     "FEEDBACK": "Feedback",
     "FEEDBACKS": "Feedbacks",
     "SETTINGS": "Settings",

--- a/src/assets/i18n/locale-ja.json
+++ b/src/assets/i18n/locale-ja.json
@@ -9,6 +9,7 @@
     "CATEGORIES": "カテゴリの管理",
     "DASHBOARD": "ダッシュボード",
     "DAY": "日",
+    "EDIT_PASSWORD": "パスワードの変更",
     "FEEDBACK": "フィードバック",
     "FEEDBACKS": "フィードバックの管理",
     "SETTINGS": "各種設定",


### PR DESCRIPTION
アカウント登録時のメール再送信について、メールアドレスが登録されていない場合のエラーの挙動を変更します。

エラーメッセージを表示するようにするために、404ではなく422で返すようにします。
