### PR TITLE
パスワードを更新するURLの変更&404エラーの挙動変更

### DIFF
--- a/app/controllers/email_user/passwords_controller.rb
+++ b/app/controllers/email_user/passwords_controller.rb
@@ -15,19 +15,16 @@ class EmailUser::PasswordsController < ApplicationController
   end
 
   def edit
-    raise ActiveRecord::RecordNotFound if @user != @token_user
     host = Rails.env.production? ? '' : 'http://localhost:3000'
     form_params = {
-      user_id: params[:id],
-      email: @user.email,
+      email: @token_user.try(:email),
       token: params[:token]
     }
     redirect_to "#{host}/#/edit_password?#{URI.encode_www_form(form_params)}"
   end
 
   def update
-    raise ActiveRecord::RecordNotFound if @user != @token_user
-    password_form = EmailUser::Password.new(@user, password_reset_params)
+    password_form = EmailUser::Password.new(@token_user, password_reset_params)
     return render_error password_form if password_form.invalid?
     return render_error password_form unless password_form.update
     head 200
@@ -36,11 +33,10 @@ class EmailUser::PasswordsController < ApplicationController
   private
 
   def set_user
-    @user = EmailUser.find(params[:id])
     @token_user = User.find_by_valid_token(:password, params[:token])
   end
 
   def password_reset_params
-    params.permit(:current_password, :password, :password_confirmation)
+    params.permit(:current_password, :password, :password_confirmation, :token)
   end
 end

--- a/app/controllers/email_user/passwords_controller.rb
+++ b/app/controllers/email_user/passwords_controller.rb
@@ -37,6 +37,6 @@ class EmailUser::PasswordsController < ApplicationController
   end
 
   def password_reset_params
-    params.permit(:current_password, :password, :password_confirmation, :token)
+    params.permit(:password, :password_confirmation, :token)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,7 +24,6 @@ class UsersController < ApplicationController
   end
 
   # PATCH /user/password
-  # TODO: /email_user/passwords/があるので統一する
   def password
     updator = User::PasswordUpdator
               .new(user: current_user, params: password_params)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,6 +24,7 @@ class UsersController < ApplicationController
   end
 
   # PATCH /user/password
+  # TODO: /email_user/passwords/があるので統一する
   def password
     updator = User::PasswordUpdator
               .new(user: current_user, params: password_params)

--- a/app/models/email_user.rb
+++ b/app/models/email_user.rb
@@ -33,7 +33,7 @@ class EmailUser < User
 
   def password_reset_url(origin)
     token = password_token.token
-    "#{origin}/email_user/passwords/#{id}/edit?token=#{token}"
+    "#{origin}/email_user/password/edit?token=#{token}"
   end
 
   def password_token

--- a/app/models/email_user/password.rb
+++ b/app/models/email_user/password.rb
@@ -1,17 +1,17 @@
 class EmailUser::Password
   include ActiveModel::Model
 
-  attr_accessor :current_password
+  attr_accessor :user, :current_password
   # validates :current_password,
   #           presence: true,
   #           length: { maximum: Settings.user.password.maximum_length }
   # TODO: プロフィール変更時、current_passwordが存在する場合に設定する
+  validates :user,
+            presence: { message: I18n.t('errors.messages.users.invalid_url') }
 
   def initialize(user, params)
     @user = user
-    if params[:current_password]
-      self.current_password = params[:current_password]
-    end
+    # @current_password = params[:current_password] if params[:current_password]
     @params = params
   end
 
@@ -27,8 +27,8 @@ class EmailUser::Password
     end
   end
 
-  def authenticate
-    return false if invalid?
-    @user.authenticate(@params[:current_password])
-  end
+  # def authenticate
+  #   return false if invalid?
+  #   @user.authenticate(@params[:current_password])
+  # end
 end

--- a/app/models/email_user/password.rb
+++ b/app/models/email_user/password.rb
@@ -2,16 +2,11 @@ class EmailUser::Password
   include ActiveModel::Model
 
   attr_accessor :user, :current_password
-  # validates :current_password,
-  #           presence: true,
-  #           length: { maximum: Settings.user.password.maximum_length }
-  # TODO: プロフィール変更時、current_passwordが存在する場合に設定する
   validates :user,
             presence: { message: I18n.t('errors.messages.users.invalid_url') }
 
   def initialize(user, params)
     @user = user
-    # @current_password = params[:current_password] if params[:current_password]
     @params = params
   end
 
@@ -26,9 +21,4 @@ class EmailUser::Password
       false
     end
   end
-
-  # def authenticate
-  #   return false if invalid?
-  #   @user.authenticate(@params[:current_password])
-  # end
 end

--- a/app/models/user/password_updator.rb
+++ b/app/models/user/password_updator.rb
@@ -27,10 +27,9 @@ class User::PasswordUpdator < User::Updator
   def authorize
     if @user.authenticate(@current_password)
       @update_params = { password: @password }
-      true
     else
       errors.add(:current_password, :invalid)
-      false
     end
+    errors.blank?
   end
 end

--- a/app/models/user/password_updator.rb
+++ b/app/models/user/password_updator.rb
@@ -1,4 +1,5 @@
 class User::PasswordUpdator < User::Updator
+  # TODO: EmailUser::Passwordと統一する
   include ActiveModel::Model
 
   attr_accessor :current_password, :password, :password_confirmation

--- a/app/models/user/password_updator.rb
+++ b/app/models/user/password_updator.rb
@@ -1,5 +1,4 @@
 class User::PasswordUpdator < User::Updator
-  # TODO: EmailUser::Passwordと統一する
   include ActiveModel::Model
 
   attr_accessor :current_password, :password, :password_confirmation

--- a/config/locales/activemodel_ja.yml
+++ b/config/locales/activemodel_ja.yml
@@ -3,6 +3,7 @@ ja:
     attributes:
       email_user/password:
         current_password: 現在のパスワード
+        user: アカウント
       email_user/registration_token:
         email: メールアドレス
       user/updator:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,6 +5,7 @@ ja:
         invalid_parameters: メールアドレスまたはパスワードが正しくありません
       users:
         invalid_token: すでに登録が完了しているか有効期限が切れたURLに接続しました。
+        invalid_url: が無効、または有効期限が切れたURLからの接続です。
       categories:
         failed_to_sort: 並び替えに失敗しました。
         destroy_breakdowns: 登録した内訳を削除してから削除してください

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,7 +48,7 @@ Rails.application.routes.draw do
     get :authorize_email
     get :settings
     patch :setting
-    patch :password #TODO: 削除する
+    patch :password
     post :send_mail, on: :collection
   end
   resource :feedback, only: %i(create)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,9 +23,10 @@ Rails.application.routes.draw do
       get :regist
       patch :recreate, on: :collection
     end
+    # TODO: resource :registrationに変更する
 
-    resources :passwords, only: %i(edit update) do
-      post :send_mail, on: :collection
+    resource :password, only: %i(edit update) do
+      post :send_mail
     end
   end
 
@@ -47,7 +48,7 @@ Rails.application.routes.draw do
     get :authorize_email
     get :settings
     patch :setting
-    patch :password
+    patch :password #TODO: 削除する
     post :send_mail, on: :collection
   end
   resource :feedback, only: %i(create)

--- a/spec/requests/password_spec.rb
+++ b/spec/requests/password_spec.rb
@@ -36,7 +36,7 @@ describe 'POST /email_user/password/send_mail?email=email', autodoc: true do
       open_email(email)
       expect(current_email.subject).to eq '【PIG BOOK β】アカウント登録状況のご確認と登録のご案内'
       expect(current_email).to have_content email
-      expect(current_email).not_to have_content '/email_user/password/'
+      expect(current_email).not_to have_content '/email_user/password/edit?'
     end
   end
 
@@ -50,7 +50,7 @@ describe 'POST /email_user/password/send_mail?email=email', autodoc: true do
       open_email(email)
       expect(current_email.subject).to eq '【PIG BOOK β】パスワードリセットのご案内'
       expect(current_email).to have_content email
-      expect(current_email).to have_content '/email_user/password/'
+      expect(current_email).to have_content '/email_user/password/edit?'
     end
   end
 end
@@ -64,6 +64,8 @@ describe 'GET /email_user/password/edit?email=email&token=token',
   let!(:params) { { email: email, token: token } }
 
   context 'ユーザーが見つからない場合' do
+    let(:email) { '' }
+
     it '302が返ってくること' do
       get '/email_user/password/edit', params
       expect(response.status).to eq 302
@@ -100,6 +102,7 @@ describe 'GET /email_user/password/edit?email=email&token=token',
   end
 end
 
+# ログインなしでパスワードを変更
 describe 'PATCH /email_user/password
   ?password=password&\password_confirmation=password_confirmation\
   &token=token', autodoc: true do

--- a/spec/requests/password_spec.rb
+++ b/spec/requests/password_spec.rb
@@ -130,49 +130,6 @@ describe 'PATCH /email_user/password
     end
   end
 
-  context '現在のパスワードが空の場合' do
-    let(:password) { '' }
-
-    it '422が返ってくること' do
-      pending 'プロフィール変更時に設定'
-      post '/email_user/password/send_mail?', email_param
-      expect(response.status).to eq 200
-
-      open_email(user.email)
-      current_email.body =~ %r{\/password\/edit\?token=(.*)}
-      token = Regexp.last_match(1)
-
-      get '/email_user/password/edit', token: token
-      expect(response.status).to eq 302
-
-      patch '/email_user/password', params.merge(token: token)
-      expect(response.status).to eq 422
-      json = {
-        error_messages: ['現在のパスワードを入力してください']
-      }
-      expect(response.body).to be_json_as(json)
-    end
-  end
-
-  context '現在のパスワードが一致しない場合' do
-    it '401が返ってくること' do
-      pending 'プロフィール変更時に設定'
-      post '/email_user/password/send_mail?', email_param
-      expect(response.status).to eq 200
-
-      open_email(user.email)
-      current_email.body =~ %r{\/password\/edit\?token=(.*)}
-      token = Regexp.last_match(1)
-
-      get '/email_user/password/edit', token: token
-      expect(response.status).to eq 302
-      params[:current_password] = 'invalid_password'
-
-      patch '/email_user/password', params.merge(token: token)
-      expect(response.status).to eq 401
-    end
-  end
-
   context '新しいパスワードが確認と一致しない場合' do
     it '422が返ってくること' do
       post '/email_user/password/send_mail?', email_param

--- a/spec/requests/password_spec.rb
+++ b/spec/requests/password_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
-describe 'POST /email_user/passwords/send_mail?email=email', autodoc: true do
+# パスワードを変更するためにメール送信
+describe 'POST /email_user/password/send_mail?email=email', autodoc: true do
   let!(:email) { 'login@example.com' }
   let!(:email_param) { { email: email } }
 
@@ -8,20 +9,20 @@ describe 'POST /email_user/passwords/send_mail?email=email', autodoc: true do
     let(:email) { '' }
 
     it '422が返ってくること' do
-      post '/email_user/passwords/send_mail', email_param
+      post '/email_user/password/send_mail', email_param
       expect(response.status).to eq 422
     end
   end
 
   context 'ユーザーが見つからない場合' do
     it '200が返り、メールが送信されること' do
-      post '/email_user/passwords/send_mail', email_param
+      post '/email_user/password/send_mail', email_param
       expect(response.status).to eq 200
 
       open_email(email)
       expect(current_email.subject).to eq '【PIG BOOK β】アカウントのご確認と登録のご案内'
       expect(current_email).to have_content email
-      expect(current_email).not_to have_content '/email_user/passwords/'
+      expect(current_email).not_to have_content '/email_user/password/edit?'
     end
   end
 
@@ -29,13 +30,13 @@ describe 'POST /email_user/passwords/send_mail?email=email', autodoc: true do
     let!(:user) { create(:email_user, :inactive, email: email) }
 
     it '200が返り、メールが送信されること' do
-      post '/email_user/passwords/send_mail', email_param
+      post '/email_user/password/send_mail', email_param
       expect(response.status).to eq 200
 
       open_email(email)
       expect(current_email.subject).to eq '【PIG BOOK β】アカウント登録状況のご確認と登録のご案内'
       expect(current_email).to have_content email
-      expect(current_email).not_to have_content '/email_user/passwords/'
+      expect(current_email).not_to have_content '/email_user/password/'
     end
   end
 
@@ -43,18 +44,19 @@ describe 'POST /email_user/passwords/send_mail?email=email', autodoc: true do
     let!(:user) { create(:email_user, :registered, email: email) }
 
     it '200が返り、メールが送信されること' do
-      post '/email_user/passwords/send_mail', email_param
+      post '/email_user/password/send_mail', email_param
       expect(response.status).to eq 200
 
       open_email(email)
       expect(current_email.subject).to eq '【PIG BOOK β】パスワードリセットのご案内'
       expect(current_email).to have_content email
-      expect(current_email).to have_content '/email_user/passwords/'
+      expect(current_email).to have_content '/email_user/password/'
     end
   end
 end
 
-describe 'GET /email_user/passwords/:id/edit?email=email&token=token',
+# パスワードの変更画面
+describe 'GET /email_user/password/edit?email=email&token=token',
          autodoc: true do
   let!(:email) { 'login@example.com' }
   let!(:token) { 'dummy_token' }
@@ -62,21 +64,21 @@ describe 'GET /email_user/passwords/:id/edit?email=email&token=token',
   let!(:params) { { email: email, token: token } }
 
   context 'ユーザーが見つからない場合' do
-    it '404が返ってくること' do
-      get '/email_user/passwords/1/edit', params
-      expect(response.status).to eq 404
+    it '302が返ってくること' do
+      get '/email_user/password/edit', params
+      expect(response.status).to eq 302
     end
   end
 
   context 'パスワードトークンが不正だった場合' do
     let!(:user) { create(:email_user, :registered, email: email) }
 
-    it '404が返ってくること' do
-      post '/email_user/passwords/send_mail', email_param
+    it '302が返ってくること' do
+      post '/email_user/password/send_mail', email_param
       expect(response.status).to eq 200
 
-      get "/email_user/passwords/#{user.id}/edit", params
-      expect(response.status).to eq 404
+      get '/email_user/password/edit', params
+      expect(response.status).to eq 302
     end
   end
 
@@ -84,22 +86,21 @@ describe 'GET /email_user/passwords/:id/edit?email=email&token=token',
     let!(:user) { create(:email_user, :registered, email: email) }
 
     it '302が返ってくること' do
-      post '/email_user/passwords/send_mail?', email_param
+      post '/email_user/password/send_mail?', email_param
       expect(response.status).to eq 200
 
       open_email(user.email)
-      current_email.body =~ %r{\/passwords\/(\d*)\/edit\?token=(.*)}
-      user_id = Regexp.last_match(1)
-      token = Regexp.last_match(2)
+      current_email.body =~ %r{\/password\/edit\?token=(.*)}
+      token = Regexp.last_match(1)
 
       params = { email: user.email, token: token }
-      get "/email_user/passwords/#{user_id}/edit", params
+      get '/email_user/password/edit', params
       expect(response.status).to eq 302
     end
   end
 end
 
-describe 'PATCH /email_user/passwords/:id\
+describe 'PATCH /email_user/password
   ?password=password&\password_confirmation=password_confirmation\
   &token=token', autodoc: true do
   let!(:user) { create(:email_user, :registered, email: email) }
@@ -115,9 +116,14 @@ describe 'PATCH /email_user/passwords/:id\
   end
 
   context 'ユーザーが見つからない場合' do
-    it '404が返ってくること' do
-      patch "/email_user/passwords/#{user.id}1", params
-      expect(response.status).to eq 404
+    it '422が返ってくること' do
+      patch '/email_user/password', params
+      expect(response.status).to eq 422
+
+      json = {
+        error_messages: ['アカウントが無効、または有効期限が切れたURLからの接続です。']
+      }
+      expect(response.body).to be_json_as(json)
     end
   end
 
@@ -126,18 +132,17 @@ describe 'PATCH /email_user/passwords/:id\
 
     it '422が返ってくること' do
       pending 'プロフィール変更時に設定'
-      post '/email_user/passwords/send_mail?', email_param
+      post '/email_user/password/send_mail?', email_param
       expect(response.status).to eq 200
 
       open_email(user.email)
-      current_email.body =~ %r{\/passwords\/(\d*)\/edit\?token=(.*)}
-      user_id = Regexp.last_match(1)
-      token = Regexp.last_match(2)
+      current_email.body =~ %r{\/password\/edit\?token=(.*)}
+      token = Regexp.last_match(1)
 
-      get "/email_user/passwords/#{user_id}/edit", token: token
+      get '/email_user/password/edit', token: token
       expect(response.status).to eq 302
 
-      patch "/email_user/passwords/#{user.id}", params.merge(token: token)
+      patch '/email_user/password', params.merge(token: token)
       expect(response.status).to eq 422
       json = {
         error_messages: ['現在のパスワードを入力してください']
@@ -149,42 +154,62 @@ describe 'PATCH /email_user/passwords/:id\
   context '現在のパスワードが一致しない場合' do
     it '401が返ってくること' do
       pending 'プロフィール変更時に設定'
-      post '/email_user/passwords/send_mail?', email_param
+      post '/email_user/password/send_mail?', email_param
       expect(response.status).to eq 200
 
       open_email(user.email)
-      current_email.body =~ %r{\/passwords\/(\d*)\/edit\?token=(.*)}
-      user_id = Regexp.last_match(1)
-      token = Regexp.last_match(2)
+      current_email.body =~ %r{\/password\/edit\?token=(.*)}
+      token = Regexp.last_match(1)
 
-      get "/email_user/passwords/#{user_id}/edit", token: token
+      get '/email_user/password/edit', token: token
       expect(response.status).to eq 302
       params[:current_password] = 'invalid_password'
 
-      patch "/email_user/passwords/#{user.id}", params.merge(token: token)
+      patch '/email_user/password', params.merge(token: token)
       expect(response.status).to eq 401
     end
   end
 
   context '新しいパスワードが確認と一致しない場合' do
     it '422が返ってくること' do
-      post '/email_user/passwords/send_mail?', email_param
+      post '/email_user/password/send_mail?', email_param
       expect(response.status).to eq 200
 
       open_email(user.email)
-      current_email.body =~ %r{\/passwords\/(\d*)\/edit\?token=(.*)}
-      user_id = Regexp.last_match(1)
-      token = Regexp.last_match(2)
+      current_email.body =~ %r{\/password\/edit\?token=(.*)}
+      token = Regexp.last_match(1)
 
-      get "/email_user/passwords/#{user_id}/edit", token: token
+      get '/email_user/password/edit', token: token
       expect(response.status).to eq 302
       params[:password] = 'invalid_password'
 
-      patch "/email_user/passwords/#{user.id}", params.merge(token: token)
+      patch '/email_user/password', params.merge(token: token)
       expect(response.status).to eq 422
 
       json = {
         error_messages: ['パスワード（確認）とパスワードの入力が一致しません']
+      }
+      expect(response.body).to be_json_as(json)
+    end
+  end
+
+  context 'トークンが正しくない場合' do
+    it '422が返ってくること' do
+      post '/email_user/password/send_mail?', email_param
+      expect(response.status).to eq 200
+
+      open_email(user.email)
+      current_email.body =~ %r{\/password\/edit\?token=(.*)}
+      token = Regexp.last_match(1)
+
+      get '/email_user/password/edit', token: token
+      expect(response.status).to eq 302
+
+      patch '/email_user/password', params.merge(token: 'dummy')
+      expect(response.status).to eq 422
+
+      json = {
+        error_messages: ['アカウントが無効、または有効期限が切れたURLからの接続です。']
       }
       expect(response.body).to be_json_as(json)
     end
@@ -196,18 +221,17 @@ describe 'PATCH /email_user/passwords/:id\
     end
 
     it '200が返り、ログインできること' do
-      post '/email_user/passwords/send_mail?', email_param
+      post '/email_user/password/send_mail?', email_param
       expect(response.status).to eq 200
 
       open_email(user.email)
-      current_email.body =~ %r{\/passwords\/(\d*)\/edit\?token=(.*)}
-      user_id = Regexp.last_match(1)
-      token = Regexp.last_match(2)
+      current_email.body =~ %r{\/password\/edit\?token=(.*)}
+      token = Regexp.last_match(1)
 
-      get "/email_user/passwords/#{user_id}/edit", token: token
+      get '/email_user/password/edit', token: token
       expect(response.status).to eq 302
 
-      patch "/email_user/passwords/#{user.id}", params.merge(token: token)
+      patch '/email_user/password', params.merge(token: token)
       expect(response.status).to eq 200
 
       post '/session', login_params

--- a/src/app/account/account.factory.coffee
+++ b/src/app/account/account.factory.coffee
@@ -45,7 +45,7 @@ AccountFactory = ($location, $q, $http, localStorageService, toastr, $translate)
 
     postResetPassword: (params) ->
       defer = $q.defer()
-      $http.post(host + 'email_user/passwords/send_mail', params)
+      $http.post(host + 'email_user/password/send_mail', params)
         .success((data) ->
           toastr.success $translate.instant('MESSAGES.SEND_MAIL')
           $location.path 'login'
@@ -58,7 +58,7 @@ AccountFactory = ($location, $q, $http, localStorageService, toastr, $translate)
 
     patchNewPassword: (user_id, params) ->
       defer = $q.defer()
-      $http.patch(host + 'email_user/passwords/' + user_id, params)
+      $http.patch(host + 'email_user/password', params)
         .success((data) ->
           toastr.success $translate.instant('MESSAGES.UPDATE_PASSWORD')
           $location.path 'login'

--- a/src/app/account/edit_password.controller.coffee
+++ b/src/app/account/edit_password.controller.coffee
@@ -13,11 +13,7 @@ EditPasswordController = (AccountFactory, $location, $translate) ->
       token: vm.token
     }
     AccountFactory.patchNewPassword(vm.user_id, params).catch (res) ->
-      if res.error_messages == 'Not Found'
-        vm.errors = [$translate.instant('MESSAGES.NOT_FOUND_EMAIL')]
-      else
-        vm.errors = res.error_messages
-      return
+      vm.errors = res.error_messages
 
   return
 

--- a/src/app/account/reset_password.jade
+++ b/src/app/account/reset_password.jade
@@ -29,7 +29,7 @@
               span.glyphicon.glyphicon-alert#left-icon
               span(translate='ERRORS.MAXLENGTH.EMAIL')
  
-        button.btn.btn-success(type='submit' ng-disabled='resetPasswordForm.$submitted && resetPasswordForm.$invalid || reset_password.sending')
+        button.btn.btn-success(type='submit' ng-disabled='resetPasswordForm.$invalid || reset_password.sending')
           span(translate='BUTTONS.SEND')
       hr
       p


### PR DESCRIPTION
- パスワードをリセットするAPIについてURLを変更しました
- ユーザーが見つからなかった場合、404ではなく422でエラーメッセージを返すようにしました
- パスワードリセット画面のボタンがdisabledになる条件を変更しました
- 上記に伴いテストを修正しました
