### PR TITLE
月末に発生していたテスト失敗を解消

### DIFF
--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -33,7 +33,7 @@ describe 'GET /dashboard', autodoc: true do
         create(:record, published_at: 1.month.ago, user: user)
       end
       let!(:last_month_record2) do
-        create(:record, published_at: 1.month.ago + 1.day, user: user)
+        create(:record, published_at: 1.month.ago, user: user)
       end
       let!(:today_record1) { create(:record, user: user) }
       let!(:today_record2) { create(:record, user: user) }
@@ -76,12 +76,7 @@ describe 'GET /dashboard', autodoc: true do
             data: [
               {
                 date: 1.month.ago.strftime('%Y-%m-%d'),
-                plus: last_month_record1.charge,
-                minus: 0
-              },
-              {
-                date: (1.month.ago + 1.day).strftime('%Y-%m-%d'),
-                plus: last_month_record2.charge,
+                plus: last_month_record1.charge + last_month_record2.charge,
                 minus: 0
               }
             ]


### PR DESCRIPTION
月末の場合、一ヶ月前の+1が当月になる場合があるため、月指定のテストで失敗していました。

+1は無くし、同じ日で合計値をテストするようにしました。
