### PR TITLE
サイトのタイトルが評価前の{{}}}が表示される問題を修正

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html ng-app="newAccountBook">
   <head>
     <meta charset="utf-8">
-    <title>{{ 'BRAND_NAME' | translate }}</title>
+    <title ng-bind="'BRAND_NAME' | translate">おこづかいちょうβ</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width">
     <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->


### PR DESCRIPTION
サイトアクセス時、ロード中に`{{ 'BRAND_NAME' | translate }}`が表示されます。

評価前の変数が表示される問題を修正しました。
