### PR TITLE
レイアウトの微調整

### DIFF
--- a/src/app/admin/feedbacks.jade
+++ b/src/app/admin/feedbacks.jade
@@ -2,7 +2,8 @@ admin-menu-directive
 
 .panel.panel-default
   .panel-heading
-    span.glyphicon.glyphicon-leaf(translate='TITLES.FEEDBACKS')
+    span.glyphicon.glyphicon-leaf#left-icon
+    span {{ 'TITLES.FEEDBACKS' | translate }}
   .panel-body#with-background
     loading-directive
     nav

--- a/src/app/admin/messages.jade
+++ b/src/app/admin/messages.jade
@@ -2,7 +2,8 @@ admin-menu-directive
 
 .panel.panel-default
   .panel-heading
-    span.glyphicon.glyphicon-leaf(translate='TITLES.MESSAGES')
+    span.glyphicon.glyphicon-leaf#left-icon
+    span {{ 'TITLES.MESSAGES' | translate }}
   .panel-body#with-background
     loading-directive
     nav

--- a/src/app/admin/notices.jade
+++ b/src/app/admin/notices.jade
@@ -2,7 +2,8 @@ admin-menu-directive
 
 .panel.panel-default
   .panel-heading
-    span.glyphicon.glyphicon-leaf(translate='TITLES.NOTICES')
+    span.glyphicon.glyphicon-leaf#left-icon
+    span {{ 'TITLES.NOTICES' | translate }}
   .panel-body#with-background
     loading-directive
     .btn.btn-info(translate='BUTTONS.ADD' ng-click='admin_notices.newNotice()' ng-show='admin_notices.notices')

--- a/src/app/admin/users.jade
+++ b/src/app/admin/users.jade
@@ -2,7 +2,8 @@ admin-menu-directive
 
 .panel.panel-default
   .panel-heading
-    span.glyphicon.glyphicon-leaf(translate='TITLES.USERS')
+    span.glyphicon.glyphicon-leaf#left-icon
+    span {{ 'TITLES.USERS' | translate }}
   .panel-body#with-background
     loading-directive
     nav

--- a/src/app/index.scss
+++ b/src/app/index.scss
@@ -100,7 +100,13 @@ body {
   span {
     outline: none;
   }
-  table tr {
+  label.control-label {
+    outline: none;
+  }
+  button.btn.btn-info.btn-sm {
+    outline: none;
+  }
+  .nav > li > a:hover, .nav > li > a:focus {
     outline: none;
   }
   table tr.mouseover {

--- a/src/app/index.scss
+++ b/src/app/index.scss
@@ -109,7 +109,10 @@ body {
   .nav > li > a:hover, .nav > li > a:focus {
     outline: none;
   }
-  table tr.mouseover {
+  td.line-color {
+    border-left: medium solid transparent;
+  }
+  td.line-color-red {
     border-left: medium solid $red;
   }
   .inline-block {

--- a/src/app/user/import_history.jade
+++ b/src/app/user/import_history.jade
@@ -18,9 +18,8 @@
         th(width='15%') {{ 'COLUMNS.MESSAGE' | translate }}
         th
       tr(ng-repeat='capture in import_history.captures'
-         ng-mouseover='import_history.selectLine($index)'
-         ng-class="{ mouseover: import_history.selectLineNumber == $index }")
-        td
+         ng-mouseover='import_history.selectLine($index)')
+        td.line-color(ng-class="{ 'line-color-red': import_history.selectLineNumber == $index}")
         td {{ capture.published_at | date:'yyyy-MM-dd' }}
         td {{ capture.category_name }}
         td {{ capture.breakdown_name }}


### PR DESCRIPTION
- モーダル表示時に選択部分で発生しているoutlineを非表示にしました
- インポート履歴の一覧で選択行がある場合とない場合でレイアウトが動く問題を修正しました
- 管理画面のパネルタイトルのアイコンと文字列の間にスペースを追加しました
