### PR TITLE
ラベルがない場合、インポートの「登録」ボタンでエラーが発生する問題を修正

### DIFF
--- a/app/models/record/generator.rb
+++ b/app/models/record/generator.rb
@@ -19,7 +19,7 @@ class Record::Generator
     }
     @tags_params = @capture.tags.split(',').map do |n|
       { id: @user.tags.find_by(name: n).try(:id), name: n }
-    end
+    end if @capture.tags
   end
 
   def save

--- a/spec/requests/records_spec.rb
+++ b/spec/requests/records_spec.rb
@@ -313,20 +313,42 @@ describe 'POST /records/import', autodoc: true do
   end
 
   context 'ログインしている場合' do
-    it '201が返ってくること' do
-      place.categories << category
-      post '/records/import', params: { capture_id: capture.id },
-                              headers: login_headers(user)
-      expect(response.status).to eq 201
-      record = user.records.last
-      expect(record.published_at).to eq capture.published_at
-      expect(record.charge).to eq capture.charge
-      expect(record.category.name).to eq capture.category_name
-      expect(record.breakdown.try(:name)).to eq capture.breakdown_name
-      expect(record.place.try(:name)).to eq capture.place_name
-      expect(record.memo).to eq capture.memo
-      expect(record.tags.count).to eq 2
-      expect(user.captures.count).to eq 0
+    context 'データが全て存在している場合' do
+      it '201が返ってくること' do
+        place.categories << category
+        post '/records/import', params: { capture_id: capture.id },
+                                headers: login_headers(user)
+        expect(response.status).to eq 201
+        record = user.records.last
+        expect(record.published_at).to eq capture.published_at
+        expect(record.charge).to eq capture.charge
+        expect(record.category.name).to eq capture.category_name
+        expect(record.breakdown.try(:name)).to eq capture.breakdown_name
+        expect(record.place.try(:name)).to eq capture.place_name
+        expect(record.memo).to eq capture.memo
+        expect(record.tags.count).to eq 2
+        expect(user.captures.count).to eq 0
+      end
+    end
+
+    context 'ラベルが空の場合' do
+      it '201が返ってくること' do
+        capture.tags = nil
+        capture.save
+        place.categories << category
+        post '/records/import', params: { capture_id: capture.id },
+                                headers: login_headers(user)
+        expect(response.status).to eq 201
+        record = user.records.last
+        expect(record.published_at).to eq capture.published_at
+        expect(record.charge).to eq capture.charge
+        expect(record.category.name).to eq capture.category_name
+        expect(record.breakdown.try(:name)).to eq capture.breakdown_name
+        expect(record.place.try(:name)).to eq capture.place_name
+        expect(record.memo).to eq capture.memo
+        expect(record.tags.count).to eq 0
+        expect(user.captures.count).to eq 0
+      end
     end
   end
 end


### PR DESCRIPTION
以下のようなエラーが発生していました。

```
NoMethodError - undefined method `split' for nil:NilClass:
  app/models/record/generator.rb:20:in `build'
  app/controllers/records_controller.rb:39:in `import'
  actionpack (5.0.0) lib/action_controller/metal/basic_implicit_render.rb:4:in `send_action'
  actionpack (5.0.0) lib/abstract_controller/base.rb:188:in `process_action'
  actionpack (5.0.0) lib/action_controller/metal/rendering.rb:30:in `process_action'

```
