### PR TITLE
登録時のラベルの選択での挙動を統一

### DIFF
--- a/src/app/records/modals/record.jade
+++ b/src/app/records/modals/record.jade
@@ -93,10 +93,12 @@ form.form-horizontal(novalidate=true name='editRecordForm' ng-submit='edit_recor
                    min-length='1'
                    max-length='20'
                    on-tag-clicked='edit_record.setColor($tag)'
+                   ng-click='tags_list = !tags_list'
                    template='app/records/tag_template.html')
           auto-complete(source='edit_record.loadTags($query)'
                         min-length='0'
                         max-results-to-show='32'
+                        ng-show='tags_list'
                         load-on-focus='true'
                         load-on-empty='true'
                         template='app/records/autocomplete_template.html')

--- a/src/app/records/new.jade
+++ b/src/app/records/new.jade
@@ -104,14 +104,14 @@
                        min-length='1'
                        max-length='20'
                        on-tag-clicked='new_record.setColor($tag)'
-                       placeholder='↓ down arrow key' 
+                       ng-click='tags_list = !tags_list'
                        template='app/records/tag_template.html')
               auto-complete(source='new_record.loadTags($query)'
                             min-length='0'
                             max-results-to-show='32'
-                            load-on-down-arrow='true'
-                            load-on-focus='false'
-                            load-on-empty='false'
+                            ng-show='tags_list'
+                            load-on-focus='true'
+                            load-on-empty='true'
                             template='app/records/autocomplete_template.html')
         // 金額
         .form-group

--- a/src/app/records/new_record.controller.coffee
+++ b/src/app/records/new_record.controller.coffee
@@ -127,12 +127,13 @@ NewRecordController = (IndexService, toastr, RecordsFactory, $scope, $uibModal, 
     vm.published_at = new Date()
     getRecordsWithDate(vm.published_at)
 
+  SettingsFactory.getTags().then (res) ->
+    vm.list_tags = res.tags
+
   # ドロップダウンリスト
   vm.loadTags = ($query) ->
-    SettingsFactory.getTags().then (res) ->
-      tags = res.tags
-      tags.filter (tag) ->
-        return tag.name.indexOf($query) != -1
+    vm.list_tags.filter (tag) ->
+      return tag.name.indexOf($query) != -1
 
   # カテゴリ「追加」ボタン -> モーダル
   vm.newCategory = () ->


### PR DESCRIPTION
「入力する」画面のラベル編集では、「↓」ボタン押下でラベル一覧が表示され、
登録情報の編集モーダル時のラベル編集では、テキストフィールドクリックでラベル一覧が表示されていました。

「↓」ボタンでは、スマホおよびタブレットで編集できない問題があり、
テキストフィールドクリックでは、ラベル一覧が出続けて邪魔になるという問題がありました。

そこで、テキストフィールドクリックで、ラベル一覧の表示非表示を切り替えられるようにしました。
それに伴い、ラベル一覧からラベルを選択後、ラベル一覧が表示されないようにしました。
