### PR TITLE
ABCサイズを制限

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,7 +24,7 @@ Documentation:
 ClassAndModuleChildren:
   EnforcedStyle: compact
 
-# ABCサイズをMAX20に緩和
+# ABCサイズをMAX23に緩和
 Metrics/AbcSize:
   Enabled: true
-  Max: 30
+  Max: 23

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,7 +24,7 @@ Documentation:
 ClassAndModuleChildren:
   EnforcedStyle: compact
 
-# ABCサイズをMAX23に緩和
+# ABCサイズをMAX20に緩和
 Metrics/AbcSize:
   Enabled: true
-  Max: 23
+  Max: 20

--- a/app/controllers/admin/messages_controller.rb
+++ b/app/controllers/admin/messages_controller.rb
@@ -26,11 +26,12 @@ class Admin::MessagesController < ApplicationController
   def send_mail
     message = Message.find(params[:message_id])
     origin = "#{request.protocol}#{request.host_with_port}"
-    if message.user.try(:email).blank?
-      render :error404, status: 404, formats: :json
-    else
-      UserMailer.confirm_message(message.user.try(:email), origin).deliver_later
+    email = message.user.try(:email)
+    if email.present?
+      UserMailer.confirm_message(email, origin).deliver_later
       message.update(sent_at: Time.zone.now) ? head(:ok) : render_error(message)
+    else
+      render :error404, status: 404, formats: :json
     end
   end
 end

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -40,7 +40,6 @@ class RecordsController < ApplicationController
     if @record.save && @capture.destroy
       head 201
     else
-      p @record.errors
       render_error @record
     end
   end

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -40,6 +40,7 @@ class RecordsController < ApplicationController
     if @record.save && @capture.destroy
       head 201
     else
+      p @record.errors
       render_error @record
     end
   end

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -22,16 +22,10 @@ class Record < ActiveRecord::Base
   scope :the_year_and_month, lambda { |year, month|
     start_day = 10.years.ago
     end_day = 10.years.since
-    if year.present? && month.present?
-      start_day = Date.new(year.to_i, month.to_i, 1)
-      end_day = start_day.end_of_month
-    elsif year.present? && month.blank?
-      start_day = Date.new(year.to_i, 1, 1)
-      end_day = start_day.end_of_year
-    elsif year.blank? && month.present?
-      start_day = Date.new(Time.zone.today.year, month.to_i, 1)
-      end_day = start_day.end_of_month
-    end
+    target_year = year.to_i.zero? ? Time.zone.today.year : year.to_i
+    target_month = month.to_i.zero? ? 1 : month.to_i
+    start_day = Date.new(target_year, target_month, 1)
+    end_day = month ? start_day.end_of_month : start_day.end_of_year
     where(published_at: start_day..end_day)
   }
   scope :order_type, lambda { |sort_type|

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -64,7 +64,6 @@ class Record < ActiveRecord::Base
     create_tagged(tag_ids)
   end
 
-  # TODO: TaggedRecordのuser_idを削除する
   def create_tagged(tag_ids)
     tagged = []
     tag_ids.each do |tag_id|

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -20,8 +20,6 @@ class Record < ActiveRecord::Base
 
   scope :the_day, -> (target_day) { where(published_at: target_day.to_date) }
   scope :the_year_and_month, lambda { |year, month|
-    start_day = 10.years.ago
-    end_day = 10.years.since
     target_year = year.to_i.zero? ? Time.zone.today.year : year.to_i
     target_month = month.to_i.zero? ? 1 : month.to_i
     start_day = Date.new(target_year, target_month, 1)
@@ -46,16 +44,21 @@ class Record < ActiveRecord::Base
 
   def create_or_update_tags(tags_params)
     return true if tags_params.blank?
+    tag_ids = create_and_update_tags(tags_params)
+    create_tagged(tag_ids)
+  end
+
+  def create_and_update_tags(tags_params)
     tag_ids = tags_params.map { |n| n['id'].nil? ? nil : n['id'] }.compact
     registered_tags = tags_params.select { |n| !n['id'].nil? }
-    unregistered_tags = tags_params.select { |n| n['id'].nil? }
     user.tags.update(tag_ids, registered_tags) if registered_tags.present?
 
-    if unregistered_tags.present?
-      created_tags = user.tags.create(unregistered_tags)
-      tag_ids.concat(created_tags.map(&:id))
-    end
-    create_tagged(tag_ids)
+    unregistered_tags = tags_params.select { |n| n['id'].nil? }
+    tag_ids.concat(create_tags(unregistered_tags))
+  end
+
+  def create_tags(unregistered_tags)
+    user.tags.create(unregistered_tags).map(&:id)
   end
 
   def create_tagged(tag_ids)

--- a/app/models/record/fetcher.rb
+++ b/app/models/record/fetcher.rb
@@ -4,18 +4,21 @@ class Record::Fetcher
 
   def initialize(user: nil, params: nil, sort_type: nil)
     @user = user
-    @params = params
     @sort_type = sort_type
+    @year = params[:year]
+    @month = params[:month]
+    @date = params[:date]
+    @offset = params[:offset]
   end
 
   def all
     records = @user.records.order_type(@sort_type)
-    records = records.the_day(@params[:date]) if @params[:date].present?
-    if @params[:year].present? || @params[:month].present?
-      records = records.the_year_and_month(@params[:year], @params[:month])
+    records = records.the_day(@date) if @date.present?
+    if @year.present? || @month.present?
+      records = records.the_year_and_month(@year, @month)
     end
     @total_count = records.count
-    records = records.offset(@params[:offset]) if @params[:offset].present?
+    records = records.offset(@offset) if @offset.present?
     records = records.limit(Settings.records.per)
     records
   end

--- a/app/models/tally.rb
+++ b/app/models/tally.rb
@@ -8,7 +8,6 @@ class Tally < ActiveRecord::Base
   def update_list(year, month)
     self.list =
       get_data(year, month)
-      .group_by { |i| i[0].to_s.slice(0, 10) }
       .map { |i|
         { date: i[0],
           plus: i[1].map { |n| n[1] if n[2] }.compact.inject(0, :+),
@@ -23,9 +22,10 @@ class Tally < ActiveRecord::Base
     from = Date.new(year, month, 1)
     to = from.end_of_month
 
-    user.records.joins(:category)
-        .where('published_at > ? and published_at < ?', from, to)
-        .pluck("date_trunc('day', published_at) as published",
-               :charge, :barance_of_payments)
+    records = user.records.joins(:category)
+                  .where('published_at > ? and published_at < ?', from, to)
+                  .pluck("date_trunc('day', published_at) as published",
+                         :charge, :barance_of_payments)
+    records.group_by { |i| i[0].to_s.slice(0, 10) }
   end
 end

--- a/db/migrate/20160904040023_remove_user_id_from_tagged_records.rb
+++ b/db/migrate/20160904040023_remove_user_id_from_tagged_records.rb
@@ -1,0 +1,5 @@
+class RemoveUserIdFromTaggedRecords < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :tagged_records, :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160826022444) do
+ActiveRecord::Schema.define(version: 20160904040023) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -163,12 +163,10 @@ ActiveRecord::Schema.define(version: 20160826022444) do
   create_table "tagged_records", force: :cascade do |t|
     t.integer  "record_id"
     t.integer  "tag_id"
-    t.integer  "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["record_id"], name: "index_tagged_records_on_record_id", using: :btree
     t.index ["tag_id"], name: "index_tagged_records_on_tag_id", using: :btree
-    t.index ["user_id"], name: "index_tagged_records_on_user_id", using: :btree
   end
 
   create_table "tags", force: :cascade do |t|

--- a/spec/requests/records_spec.rb
+++ b/spec/requests/records_spec.rb
@@ -63,6 +63,13 @@ describe 'GET /records', autodoc: true do
       end
     end
 
+    context '年、月のパラメータが不正な場合' do
+      it '422が返ってくること' do
+        pending
+        expect(true).to be_falsey
+      end
+    end
+
     context '年、月のパラメータがある場合' do
       let!(:params) { { year: 2016, month: 1.month.ago.month } }
 

--- a/spec/requests/records_spec.rb
+++ b/spec/requests/records_spec.rb
@@ -64,9 +64,20 @@ describe 'GET /records', autodoc: true do
     end
 
     context '年、月のパラメータが不正な場合' do
-      it '422が返ってくること' do
-        pending
-        expect(true).to be_falsey
+      let!(:params) { { year: 'abcde', month: 'abcde' } }
+
+      it '200と空のデータを返すこと' do
+        get '/records', params: params, headers: login_headers(user)
+        expect(response.status).to eq 200
+
+        json = {
+          records: [],
+          total_count: 0,
+          user: {
+            currency: user.currency
+          }
+        }
+        expect(response.body).to be_json_as(json)
       end
     end
 


### PR DESCRIPTION
- ABCサイズが30だったものを20にまで制限しました
- `models/record.rb`のscopeをリファクタリングし、行数を削減しました
