### PR TITLE
金額を入力しないままインポート履歴から「登録」した場合、登録できない

### DIFF
--- a/app/models/record/generator.rb
+++ b/app/models/record/generator.rb
@@ -17,7 +17,7 @@ class Record::Generator
     @record_params = {
       published_at: @capture.published_at, memo: @capture.memo,
       category_id: @capture.category_id, breakdown_id: @capture.breakdown_id,
-      place_id: @capture.place_id, charge: @capture.charge
+      place_id: @capture.place_id, charge: @capture.charge || 0
     }
     @tags_params = @capture.tags.split(',').map do |n|
       { id: @user.tags.find_by(name: n).try(:id), name: n }


### PR DESCRIPTION
「登録」時にインポートデータの金額がnullの状態で保存されており、それをrecordに登録しようとしたために、422エラーが発生していました。

よって、インポートデータの金額にnullが入っていた場合は、recordには0を登録するようにすることで422エラーを回避するようにしました。
