### PR TITLE
リストのURLを日付に連動するパスに変更

### DIFF
--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -7,7 +7,7 @@ class MypagesController < ApplicationController
     @messages = Message::Fetcher.all(params: params, user: current_user)
     fetcher = Record::Fetcher
               .new(user: current_user, params: params, sort_type: 'lately')
-    @records = fetcher.all
+    @records = fetcher.mypage
     @user = current_user
   end
 end

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -19,20 +19,8 @@ class Record < ActiveRecord::Base
   validates :memo, length: { maximum: Settings.record.memo.maximum_length }
 
   scope :the_day, -> (target_day) { where(published_at: target_day.to_date) }
-  scope :the_year_and_month, lambda { |year, month|
-    target_year = year.to_i.zero? ? Time.zone.today.year : year.to_i
-    target_month = month.to_i.zero? ? 1 : month.to_i
-    start_day = Date.new(target_year, target_month, 1)
-    end_day = month ? start_day.end_of_month : start_day.end_of_year
-    where(published_at: start_day..end_day)
-  }
-  scope :order_type, lambda { |sort_type|
-    if sort_type == 'lately'
-      order(created_at: :desc)
-    else
-      order(published_at: :desc, created_at: :desc)
-    end
-  }
+  scope :the_month, -> (first_day) { where(published_at: first_day..first_day.end_of_month) }
+  scope :the_year, -> (first_day) { where(published_at: first_day..first_day.end_of_year) }
 
   def update_with_tags(record_params, tags_params)
     if update(record_params)

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -19,8 +19,12 @@ class Record < ActiveRecord::Base
   validates :memo, length: { maximum: Settings.record.memo.maximum_length }
 
   scope :the_day, -> (target_day) { where(published_at: target_day.to_date) }
-  scope :the_month, -> (first_day) { where(published_at: first_day..first_day.end_of_month) }
-  scope :the_year, -> (first_day) { where(published_at: first_day..first_day.end_of_year) }
+  scope :the_month, lambda { |first_day|
+    where(published_at: first_day..first_day.end_of_month)
+  }
+  scope :the_year, lambda { |first_day|
+    where(published_at: first_day..first_day.end_of_year)
+  }
 
   def update_with_tags(record_params, tags_params)
     if update(record_params)

--- a/app/models/record/fetcher.rb
+++ b/app/models/record/fetcher.rb
@@ -33,7 +33,7 @@ class Record::Fetcher
   private
 
   def find_by_date(records)
-    records = if @day.nonzero?
+    if @day.nonzero?
       records.the_day(Date.new(@year, @month, @day))
     elsif @month.nonzero?
       records.the_month(Date.new(@year, @month, 1))

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -97,14 +97,6 @@ ActiveRecord::Schema.define(version: 20160921120022) do
     t.index ["user_id"], name: "index_feedbacks_on_user_id", using: :btree
   end
 
-  create_table "items", force: :cascade do |t|
-    t.string   "name",        limit: 255
-    t.integer  "price"
-    t.text     "description"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
   create_table "messages", force: :cascade do |t|
     t.integer  "user_id"
     t.integer  "feedback_id"
@@ -193,8 +185,8 @@ ActiveRecord::Schema.define(version: 20160921120022) do
 
   create_table "tokens", force: :cascade do |t|
     t.string   "name",             null: false
-    t.integer  "tokenizable_id",   null: false
     t.string   "tokenizable_type", null: false
+    t.integer  "tokenizable_id",   null: false
     t.string   "token",            null: false
     t.text     "data"
     t.datetime "expires_at"

--- a/spec/requests/records_spec.rb
+++ b/spec/requests/records_spec.rb
@@ -19,7 +19,8 @@ describe 'GET /records', autodoc: true do
     let!(:tag) { create(:tag, user: user) }
 
     context '日付のパラメータがある場合' do
-      let!(:params) { { date: Time.zone.today } }
+      let!(:today) { Time.zone.today }
+      let!(:params) { { year: today.year, month: today.month, day: today.day } }
 
       it '200と当日の収支一覧を返すこと' do
         record2.tags << tag
@@ -66,13 +67,36 @@ describe 'GET /records', autodoc: true do
     context '年、月のパラメータが不正な場合' do
       let!(:params) { { year: 'abcde', month: 'abcde' } }
 
-      it '200と空のデータを返すこと' do
+      it '200と今日のデータを返すこと' do
         get '/records', params: params, headers: login_headers(user)
         expect(response.status).to eq 200
 
         json = {
-          records: [],
-          total_count: 0,
+          records: [
+            {
+              id: record2.id,
+              published_at: record2.published_at.strftime('%Y-%m-%d'),
+              payments: record2.category.barance_of_payments,
+              charge: record2.charge,
+              category_name: record2.category.name,
+              breakdown_name: record2.breakdown.try(:name),
+              place_name: record2.place.try(:name),
+              memo: record2.memo,
+              tags: []
+            },
+            {
+              id: record1.id,
+              published_at: record1.published_at.strftime('%Y-%m-%d'),
+              payments: record1.category.barance_of_payments,
+              charge: record1.charge,
+              category_name: record1.category.name,
+              breakdown_name: record1.breakdown.try(:name),
+              place_name: record1.place.try(:name),
+              memo: record1.memo,
+              tags: []
+            }
+          ],
+          total_count: 2,
           user: {
             currency: user.currency
           }

--- a/src/app/index.route.coffee
+++ b/src/app/index.route.coffee
@@ -116,6 +116,24 @@ angular.module 'newAccountBook'
         templateUrl: 'app/records/list/list.html'
         controllerAs: 'list'
         controller: 'RecordsController'
+      # リスト画面（年）
+      .state 'yearly_list',
+        url: '/list/{year:201[2-6]+}'
+        templateUrl: 'app/records/list/list.html'
+        controllerAs: 'list'
+        controller: 'RecordsController'
+      # リスト画面（月）
+      .state 'monthly_list',
+        url: '/list/{year:201[2-6]+}/{month:[0|1]*[0-9]+}'
+        templateUrl: 'app/records/list/list.html'
+        controllerAs: 'list'
+        controller: 'RecordsController'
+      # リスト画面（日）
+      .state 'daily_list',
+        url: '/list/{year:201[2-6]+}/{month:[0|1]*[0-9]+}/{day:[0-9]{1,2}}'
+        templateUrl: 'app/records/list/list.html'
+        controllerAs: 'list'
+        controller: 'RecordsController'
       # ダッシュボード画面
       .state 'dashboard',
         url: '/dashboard'

--- a/src/app/records/list/list.jade
+++ b/src/app/records/list/list.jade
@@ -20,8 +20,13 @@ form.form.form-inline
   // 月
   ol.breadcrumb.inline-block(ng-show="list.selected_list == 'month'")
     li(ng-repeat='month in list.months')
-      a(href='' ng-click='list.selectMonth(month)' ng-style="{'font-weight': list.month == month ? 'bold' : 'normal'}") {{ month }} 月
-  select.form-control(ng-model='list.year' ng-show="list.selected_list == 'month'" ng-options="year as year + ' 年' for year in list.years" ng-value='list.year' ng-change='list.selectYearMonth(list.year)')
+      a(ui-sref="monthly_list({year:(list.year || today_year), month:('0'+month).slice(-2)})"
+        ng-style="{'font-weight': list.month == month ? 'bold' : 'normal'}") {{ month }} 月
+  select.form-control(ng-model='list.year'
+                      ng-show="list.selected_list == 'month'"
+                      ng-options="year as year + ' 年' for year in list.years"
+                      ng-value='list.year'
+                      ng-change='list.selectYearMonth(list.year)')
 
   // 日
   input.btn.btn-default(type='date' ng-model='list.date' datepicker-popup=true required='true' ng-change='list.changeDate()' ng-show="list.selected_list == 'day'")

--- a/src/app/records/list/list.jade
+++ b/src/app/records/list/list.jade
@@ -2,14 +2,17 @@ form.form.form-inline
   // 年、月、日
   ol.breadcrumb.inline-block
     li
-      a(translate='TITLES.YEAR' href='' ng-hide="list.selected_list == 'year'" ng-click='list.selectYearList()')
-      b(translate='TITLES.YEAR' ng-show="list.selected_list == 'year'")
+      a(ui-sref='yearly_list({year:(list.year || today_year)})'
+        ng-hide="list.selected_list == 'year'") {{ 'TITLES.YEAR' | translate }}
+      b(ng-show="list.selected_list == 'year'") {{ 'TITLES.YEAR' | translate }}
     li
-      a(translate='TITLES.MONTH' href='' ng-hide="list.selected_list == 'month'" ng-click='list.selectMonthList()')
-      b(translate='TITLES.MONTH' ng-show="list.selected_list == 'month'")
+      a(ui-sref="monthly_list({year:(list.year || today_year), month:('0'+(list.month || list.today_month)).slice(-2)})"
+        ng-hide="list.selected_list == 'month'") {{ 'TITLES.MONTH' | translate }}
+      b(ng-show="list.selected_list == 'month'") {{ 'TITLES.MONTH' | translate }}
     li
-      a(translate='TITLES.DAY' href='' ng-hide="list.selected_list == 'day'" ng-click='list.selectDayList()')
-      b(translate='TITLES.DAY' ng-show="list.selected_list == 'day'")
+      a(ui-sref="daily_list({year:(list.year || today_year), month:('0'+(list.month || list.today_month)).slice(-2), day:('0'+(list.day || list.today_day)).slice(-2)})"
+        ng-hide="list.selected_list == 'day'") {{ 'TITLES.DAY' | translate }}
+      b(ng-show="list.selected_list == 'day'") {{ 'TITLES.DAY' | translate }}
 
   // 年
   select.form-control(ng-model='list.year' ng-show="list.selected_list == 'year'" ng-options="year as year + ' 年' for year in list.years" ng-value="list.year" ng-change='list.selectYear(list.year)')
@@ -21,7 +24,7 @@ form.form.form-inline
   select.form-control(ng-model='list.year' ng-show="list.selected_list == 'month'" ng-options="year as year + ' 年' for year in list.years" ng-value='list.year' ng-change='list.selectYearMonth(list.year)')
 
   // 日
-  input.btn.btn-default(type='date' ng-model='list.day' datepicker-popup=true required='true' ng-change='list.changeDate()' ng-show="list.selected_list == 'day'")
+  input.btn.btn-default(type='date' ng-model='list.date' datepicker-popup=true required='true' ng-change='list.changeDate()' ng-show="list.selected_list == 'day'")
 
 // リスト
 .panel.panel-default

--- a/src/app/records/records.controller.coffee
+++ b/src/app/records/records.controller.coffee
@@ -1,27 +1,22 @@
-RecordsController = ($filter, IndexService , RecordsFactory, localStorageService, $uibModal) ->
+RecordsController = ($filter, IndexService , RecordsFactory, localStorageService, $uibModal, $stateParams, $state) ->
   'ngInject'
   vm = this
   vm.offset = 0
   vm.years = [2012..2017]
   vm.months = [1..12]
   vm.selected_list = localStorageService.get('selected_list') || 'month'
-
-  vm.day = new Date()
-  vm.year = Number($filter('date')(vm.day, 'yyyy'))
-  vm.month = Number($filter('date')(vm.day, 'MM'))
+  vm.today = new Date()
+  vm.today_year = Number($filter('date')(vm.today, 'yyyy'))
+  vm.today_month = Number($filter('date')(vm.today, 'MM'))
+  vm.today_day = Number($filter('date')(vm.today, 'dd'))
 
   # 登録情報を取得する関数
   getRecordsWithDate = () ->
     IndexService.loading = true
-    params = if vm.selected_list == 'day'
-      date: vm.day
-      offset: vm.offset
-    else if vm.selected_list == 'month'
+    params =
       year: vm.year
       month: vm.month
-      offset: vm.offset
-    else if vm.selected_list == 'year'
-      year: vm.year
+      day: vm.day
       offset: vm.offset
     RecordsFactory.getRecords(params).then((res) ->
       vm.records = res.records
@@ -41,7 +36,6 @@ RecordsController = ($filter, IndexService , RecordsFactory, localStorageService
     localStorageService.set 'selected_list', 'day'
     vm.selected_list = 'day'
     vm.offset = 0
-    getRecordsWithDate()
 
   vm.changeDate = () ->
     vm.offset = 0
@@ -52,29 +46,44 @@ RecordsController = ($filter, IndexService , RecordsFactory, localStorageService
     localStorageService.set 'selected_list', 'month'
     vm.selected_list = 'month'
     vm.offset = 0
-    getRecordsWithDate()
 
   vm.selectMonth = (month) ->
     vm.month = month
     vm.offset = 0
-    getRecordsWithDate()
 
   vm.selectYearMonth = (year) ->
     vm.year = year
     vm.offset = 0
-    getRecordsWithDate()
 
   # 年
   vm.selectYearList = () ->
     localStorageService.set 'selected_list', 'year'
     vm.selected_list = 'year'
     vm.offset = 0
-    getRecordsWithDate()
 
   vm.selectYear = (year) ->
     vm.year = year
     vm.offset = 0
-    getRecordsWithDate()
+
+  if $stateParams.day
+    vm.day = $stateParams.day
+    vm.selectDayList()
+  else if $stateParams.month
+    vm.selectMonthList()
+  else if $stateParams.year
+    vm.selectYearList()
+  else
+    if vm.selected_list == 'year'
+      $state.go('yearly_list', { year: vm.today_year })
+    else if vm.selected_list == 'month'
+      $state.go('monthly_list', { year: vm.today_year, month: vm.today_month })
+    else
+      $state.go('daily_list', { year: vm.today_year, month: vm.today_month, day: vm.today_day })
+
+  vm.year = Number($stateParams.year)
+  vm.month = Number($stateParams.month)
+  vm.day = Number($stateParams.day)
+  vm.date = new Date(vm.year, vm.month - 1, vm.day)
 
   # ページング
   vm.clickPaginate = (offset) ->
@@ -110,15 +119,10 @@ RecordsController = ($filter, IndexService , RecordsFactory, localStorageService
   vm.downloadCSV = () ->
     IndexService.loading = true
     vm.downloading = true
-    params = if vm.selected_list == 'day'
-      date: vm.day
-      offset: vm.offset
-    else if vm.selected_list == 'month'
+    params =
       year: vm.year
       month: vm.month
-      offset: vm.offset
-    else if vm.selected_list == 'year'
-      year: vm.year
+      day: vm.day
       offset: vm.offset
     RecordsFactory.getCSVRecords(params).then((res) ->
       if window.navigator.msSaveOrOpenBlob
@@ -137,7 +141,6 @@ RecordsController = ($filter, IndexService , RecordsFactory, localStorageService
       IndexService.loading = false
       vm.downloading = false
 
-  # リスト表示
   getRecordsWithDate()
 
   return

--- a/src/app/records/records.controller.coffee
+++ b/src/app/records/records.controller.coffee
@@ -37,9 +37,14 @@ RecordsController = ($filter, IndexService , RecordsFactory, localStorageService
     vm.selected_list = 'day'
     vm.offset = 0
 
+  # 日付の変更
   vm.changeDate = () ->
     vm.offset = 0
-    getRecordsWithDate()
+    $state.go('daily_list',
+      year: Number($filter('date')(vm.date, 'yyyy'))
+      month: ('0' + Number($filter('date')(vm.date, 'MM'))).slice(-2)
+      day: ('0' + Number($filter('date')(vm.date, 'dd'))).slice(-2)
+    )
 
   # 月
   vm.selectMonthList = () ->
@@ -47,13 +52,11 @@ RecordsController = ($filter, IndexService , RecordsFactory, localStorageService
     vm.selected_list = 'month'
     vm.offset = 0
 
-  vm.selectMonth = (month) ->
-    vm.month = month
-    vm.offset = 0
-
+  # 年を切り替えるレセクトボックス
   vm.selectYearMonth = (year) ->
     vm.year = year
     vm.offset = 0
+    getRecordsWithDate()
 
   # 年
   vm.selectYearList = () ->
@@ -61,9 +64,11 @@ RecordsController = ($filter, IndexService , RecordsFactory, localStorageService
     vm.selected_list = 'year'
     vm.offset = 0
 
+  # 年を切り替えるセレクトボックス
   vm.selectYear = (year) ->
     vm.year = year
     vm.offset = 0
+    getRecordsWithDate()
 
   if $stateParams.day
     vm.day = $stateParams.day


### PR DESCRIPTION
リストのURLは、現在`/list`のみですが、URLを以下のようにすることで日付からリストを表示することができるようにしました。

例）
2016年 `/list/2016`
2016年10月 `/list/2016/10`
2016年10月1日 `/list/2016/10/01`

listのみのアクセスの場合は、`selected_list`の値によって、今日の日付を基に対象のURLへアクセスするようにしました

例）
selected_listが`month`の場合、`/list/2016/10`
